### PR TITLE
Add game mode and car color selection to Music Select

### DIFF
--- a/src/main/engine/omusic.cpp
+++ b/src/main/engine/omusic.cpp
@@ -550,7 +550,12 @@ void OMusic::check_start()
     // than writing config.xml on every shifter movement.
     config.save();
 
-    if (game_mode_selected == Outrun::MODE_TTRIAL)
+    // If cannonball_mode is already TIME TRIAL, the legacy frontend has just
+    // performed its course selection and this is its normal music screen. Do
+    // not send that path back to the course map. Only a Time Trial newly chosen
+    // here needs to enter the selector.
+    if (game_mode_selected == Outrun::MODE_TTRIAL &&
+        outrun.cannonball_mode != Outrun::MODE_TTRIAL)
     {
         pending_music_selected = music_selected;
         return_from_time_trial = true;
@@ -581,7 +586,9 @@ void OMusic::check_start()
 
     // Music-select mode switching happens after boot(), so refresh the correct
     // high-score table now rather than leaving the table from the launch mode.
-    config.load_scores(game_mode_selected == Outrun::MODE_ORIGINAL);
+    // Time Trial owns a separate score table that was already loaded by TTrial.
+    if (game_mode_selected != Outrun::MODE_TTRIAL)
+        config.load_scores(game_mode_selected == Outrun::MODE_ORIGINAL);
 
     outrun.game_state = GS_INIT_GAME;
     ologo.disable();

--- a/src/main/engine/omusic.cpp
+++ b/src/main/engine/omusic.cpp
@@ -16,7 +16,10 @@
 #include "engine/otiles.hpp"
 #include "engine/otraffic.hpp"
 #include "engine/ostats.hpp"
+#include "frontend/menu.hpp"
 #include "directx/ffeedback.hpp"
+
+extern Menu* menu;
 
 OMusic omusic;
 
@@ -26,6 +29,12 @@ OMusic::OMusic(void)
     tile_patch = NULL;
     ffb_detent_spring_applied = -1;
     ffb_detent_target_applied = 0;
+    game_mode_selected = Outrun::MODE_ORIGINAL;
+    menu_gear_initialized = false;
+    menu_gear_state = false;
+    return_from_time_trial = false;
+    skip_music_tick = false;
+    pending_music_selected = 0;
 }
 
 
@@ -33,6 +42,109 @@ OMusic::~OMusic(void)
 {
     if (tilemap)    delete tilemap;
     if (tile_patch) delete tile_patch;
+}
+
+void OMusic::set_game_mode(int mode)
+{
+    if (mode == Outrun::MODE_ORIGINAL ||
+        mode == Outrun::MODE_CONT ||
+        mode == Outrun::MODE_TTRIAL)
+    {
+        game_mode_selected = mode;
+    }
+}
+
+void OMusic::cycle_game_mode()
+{
+    if (game_mode_selected == Outrun::MODE_ORIGINAL)
+        set_game_mode(Outrun::MODE_CONT);
+    else if (game_mode_selected == Outrun::MODE_CONT)
+        set_game_mode(Outrun::MODE_TTRIAL);
+    else
+        set_game_mode(Outrun::MODE_ORIGINAL);
+}
+
+void OMusic::cycle_car_color(int direction)
+{
+    int color = config.engine.car_pal + direction;
+
+    if (color < 0)
+        color = 4;
+    else if (color > 4)
+        color = 0;
+
+    config.engine.car_pal = color;
+}
+
+void OMusic::set_continuous_traffic_from_difficulty()
+{
+    // Continuous no longer needs a separate traffic choice when launched from
+    // the arcade flow. Start with the same traffic density as stage 1 of the
+    // selected original-game difficulty. The existing continuous setting is
+    // retained only for backwards compatibility with the legacy frontend.
+    static const uint8_t TRAFFIC_BY_DIFFICULTY[] = { 2, 3, 4, 5 };
+
+    int difficulty = config.engine.dip_traffic;
+    if (difficulty < 0)
+        difficulty = 0;
+    else if (difficulty > 3)
+        difficulty = 3;
+
+    outrun.custom_traffic = TRAFFIC_BY_DIFFICULTY[difficulty];
+}
+
+void OMusic::draw_color_swatch(uint16_t x, uint16_t y)
+{
+    // Reserve text palette 7 for the music-screen colour swatch. Fill all of
+    // its visible colour entries with one RGB value, then draw the wide rev-bar
+    // tile as a compact solid block. The normal game palette is rebuilt during
+    // GS_INIT_GAME, so this temporary palette cannot leak into the race HUD.
+    static const uint16_t CAR_COLORS[] =
+    {
+        0x100F, // Red
+        0x4F00, // Blue
+        0x30FF, // Yellow
+        0x20F0, // Green
+        0x6FF0, // Cyan
+    };
+
+    int color = config.engine.car_pal;
+    if (color < 0 || color > 4)
+        color = 0;
+
+    uint32_t pal_addr = 0x120000 + (7 * 0x20);
+    video.write_pal16(&pal_addr, 0);
+    for (int i = 1; i < 16; i++)
+        video.write_pal16(&pal_addr, CAR_COLORS[color]);
+
+    // Priority + palette 7 + tile 0x1FD (the filled/wide rev-counter segment).
+    video.write_text16(ohud.translate(x, y), 0x8FFD);
+}
+
+void OMusic::draw_game_options()
+{
+    const char* mode_name = "ORIGINAL";
+
+    if (game_mode_selected == Outrun::MODE_CONT)
+        mode_name = "CONTINUOUS";
+    else if (game_mode_selected == Outrun::MODE_TTRIAL)
+        mode_name = "TIME TRIAL";
+
+    const std::string mode_line = std::string("MODE: ") + mode_name;
+    const int mode_x = 20 - (static_cast<int>(mode_line.length()) / 2);
+
+    // These rows sit around the existing PRESS START prompt without replacing
+    // the original ROM text. Clear them first because mode names have different
+    // lengths when the player cycles between them.
+    ohud.blit_text_new(0, 18, "                                        ", OHud::GREY);
+    ohud.blit_text_new(mode_x, 18, mode_line.c_str(), OHud::GREEN);
+
+    ohud.blit_text_new(0, 19, "                                        ", OHud::GREY);
+    ohud.blit_text_new(16, 19, "COLOR", OHud::GREY);
+    draw_color_swatch(22, 19);
+
+    ohud.blit_text_new(0, 23, "                                        ", OHud::GREY);
+    ohud.blit_text_new(11, 23, "VIEW - CHANGE MODE", OHud::GREY);
 }
 
 int OMusic::get_music_selected()
@@ -197,6 +309,37 @@ bool OMusic::load_widescreen_map(std::string path)
 // Source: 0xB342
 void OMusic::enable()
 {
+    // Returning from the Time Trial course map normally causes the engine to
+    // visit GS_INIT_MUSIC again. If this Time Trial was launched from the music
+    // screen, preserve the song already chosen and turn that second visit into
+    // a one-tick handoff straight to GS_INIT_GAME.
+    if (return_from_time_trial && outrun.cannonball_mode == Outrun::MODE_TTRIAL)
+    {
+        return_from_time_trial = false;
+        skip_music_tick = true;
+        total_tracks = static_cast<int>(config.sound.music.size());
+
+        if (pending_music_selected < 0 || pending_music_selected >= total_tracks)
+            pending_music_selected = 0;
+
+        cursor_pos = pending_music_selected;
+        music_selected = pending_music_selected;
+        last_music_selected = pending_music_selected;
+
+        // GS_INIT_MUSIC increments playcount before calling enable(). This is
+        // the same play, not a second credit, so cancel that duplicate count.
+        if (config.stats.playcount > 0)
+            config.stats.playcount--;
+
+        video.enabled = false;
+        return;
+    }
+
+    // A cancelled course selection returns to the normal frontend without
+    // changing cannonball_mode, so do not let a stale marker skip a later game.
+    return_from_time_trial = false;
+    skip_music_tick = false;
+
     oferrari.car_ctrl_active = false;
     video.clear_text_ram();
     osprites.disable_sprites();
@@ -247,6 +390,17 @@ void OMusic::enable()
     music_selected = cursor_pos;
     ffb_detent_spring_applied = -1;
     ffb_detent_target_applied = 0;
+
+    if (outrun.cannonball_mode == Outrun::MODE_CONT)
+        set_game_mode(Outrun::MODE_CONT);
+    else if (outrun.cannonball_mode == Outrun::MODE_TTRIAL)
+        set_game_mode(Outrun::MODE_TTRIAL);
+    else
+        set_game_mode(Outrun::MODE_ORIGINAL);
+
+    menu_gear_state = oinputs.gear;
+    menu_gear_initialized = true;
+    draw_game_options();
 }
 
 void OMusic::disable()
@@ -346,22 +500,109 @@ void OMusic::setup_sprite5()
     osprites.map_palette(e);
 }
 
-// Check for start button during music selection screen
+// Check for mode, colour and start input during music selection screen
 //
 // Source: 0xB768
 void OMusic::check_start()
 {
-    if (ostats.credits && input.has_pressed(Input::START))
+    // Direct three-button cabinets select modes immediately. The traditional
+    // single VIEW button cycles through the same three choices.
+    if (input.has_pressed(Input::VIEW1))
+        set_game_mode(Outrun::MODE_ORIGINAL);
+    else if (input.has_pressed(Input::VIEW2))
+        set_game_mode(Outrun::MODE_CONT);
+    else if (input.has_pressed(Input::VIEW3))
+        set_game_mode(Outrun::MODE_TTRIAL);
+    else if (input.has_pressed(Input::VIEWPOINT))
+        cycle_game_mode();
+
+    // Use the shifter as a colour selector only on this screen. A real arcade
+    // LOW/HIGH shifter naturally moves backwards/forwards through the palette;
+    // separate gear buttons and automatic setups get explicit previous/next.
+    if (config.controls.gear == config.controls.GEAR_SEPARATE ||
+        config.controls.gear == config.controls.GEAR_AUTO)
     {
-        outrun.game_state = GS_INIT_GAME;
+        if (input.has_pressed(Input::GEAR1))
+            cycle_car_color(-1);
+        else if (input.has_pressed(Input::GEAR2))
+            cycle_car_color(1);
+    }
+    else
+    {
+        const bool gear_now = oinputs.gear;
+
+        if (!menu_gear_initialized)
+        {
+            menu_gear_state = gear_now;
+            menu_gear_initialized = true;
+        }
+        else if (gear_now != menu_gear_state)
+        {
+            cycle_car_color(gear_now ? 1 : -1);
+            menu_gear_state = gear_now;
+        }
+    }
+
+    if (!ostats.credits || !input.has_pressed(Input::START))
+        return;
+
+    // Persist the selected car colour when the player commits to a run rather
+    // than writing config.xml on every shifter movement.
+    config.save();
+
+    if (game_mode_selected == Outrun::MODE_TTRIAL)
+    {
+        pending_music_selected = music_selected;
+        return_from_time_trial = true;
+
+        // The Time Trial selector provides its own ambience. Stop a custom WAV
+        // preview before handing control to the frontend course map.
+        cannonball::audio.clear_wav();
+        osoundint.queue_sound(sound::FM_RESET);
+
         ologo.disable();
         disable();
+
+        if (menu)
+        {
+            menu->start_time_trial_from_music();
+            return;
+        }
+
+        // Defensive fallback for builds without a frontend menu object.
+        return_from_time_trial = false;
+        set_game_mode(Outrun::MODE_ORIGINAL);
     }
+
+    outrun.cannonball_mode = game_mode_selected;
+
+    if (game_mode_selected == Outrun::MODE_CONT)
+        set_continuous_traffic_from_difficulty();
+
+    // Music-select mode switching happens after boot(), so refresh the correct
+    // high-score table now rather than leaving the table from the launch mode.
+    config.load_scores(game_mode_selected == Outrun::MODE_ORIGINAL);
+
+    outrun.game_state = GS_INIT_GAME;
+    ologo.disable();
+    disable();
 }
 
 // Tick and Blit
 void OMusic::tick()
 {
+    // Time Trial selected from this screen has already chosen its music. The
+    // frontend restarted the engine after course selection, so skip the normal
+    // second music screen and let GS_INIT_GAME use the remembered song.
+    if (skip_music_tick)
+    {
+        skip_music_tick = false;
+        ostats.frame_counter = ostats.frame_reset + 1;
+        outrun.game_state = GS_INIT_GAME;
+        video.enabled = false;
+        return;
+    }
+
     // Radio Sprite
     osprites.do_spr_order_shadows(&osprites.jump_table[entry_start + 0]);
 
@@ -385,6 +626,8 @@ void OMusic::tick()
     osprites.do_spr_order_shadows(e);
     osprites.do_spr_order_shadows(dial);
     osprites.do_spr_order_shadows(hand);;
+
+    draw_game_options();
 
     // Enhancement: Preview Music On Sound Selection Screen
     if (config.sound.preview)

--- a/src/main/engine/omusic.cpp
+++ b/src/main/engine/omusic.cpp
@@ -130,21 +130,70 @@ void OMusic::draw_game_options()
     else if (game_mode_selected == Outrun::MODE_TTRIAL)
         mode_name = "TIME TRIAL";
 
-    const std::string mode_line = std::string("MODE: ") + mode_name;
-    const int mode_x = 20 - (static_cast<int>(mode_line.length()) / 2);
+    // Draw arbitrary text with the same two-row System 16 font used by the
+    // original SELECT MUSIC prompt. Supplying the palette base separately lets
+    // the instruction use the exact ROM style while the selected mode uses the
+    // same yellow/black style as the song title.
+    auto draw_double_row_centered = [](uint8_t y, const char* text, uint16_t pal)
+    {
+        int length = static_cast<int>(strlen(text));
+        if (length > 40)
+            length = 40;
 
-    // These rows sit around the existing PRESS START prompt without replacing
-    // the original ROM text. Clear them first because mode names have different
-    // lengths when the player cycles between them.
-    ohud.blit_text_new(0, 18, "                                        ", OHud::GREY);
-    ohud.blit_text_new(mode_x, 18, mode_line.c_str(), OHud::GREEN);
+        const int x_start = 20 - (length / 2);
 
-    ohud.blit_text_new(0, 19, "                                        ", OHud::GREY);
-    ohud.blit_text_new(16, 19, "COLOR", OHud::GREY);
-    draw_color_swatch(22, 19);
+        // Clear both rows first, since the three mode names have different
+        // lengths and otherwise leave characters behind when cycling.
+        for (int x = 0; x < 40; x++)
+        {
+            video.write_text16(ohud.translate(x, y), 0);
+            video.write_text16(ohud.translate(x, y) + 0x80, 0);
+        }
 
-    ohud.blit_text_new(0, 23, "                                        ", OHud::GREY);
-    ohud.blit_text_new(11, 23, "VIEW - CHANGE MODE", OHud::GREY);
+        uint32_t dst_addr = ohud.translate(x_start, y);
+
+        for (int i = 0; i < length; i++)
+        {
+            uint16_t c = static_cast<uint8_t>(text[i]);
+
+            if (c >= 'a' && c <= 'z')
+                c -= 0x20;
+
+            if (c == ' ')
+            {
+                video.write_text16(&dst_addr, 0);
+                video.write_text16(0x7E + dst_addr, 0);
+            }
+            else if (c >= 'A' && c <= 'Z')
+            {
+                c = ((c - 'A') * 2) + pal;
+                video.write_text16(&dst_addr, c);
+                video.write_text16(0x7E + dst_addr, c + 1);
+            }
+        }
+    };
+
+    // Extract the palette directly from the original SELECT MUSIC BY STEERING
+    // ROM text record, so the new instruction has exactly the same colours.
+    uint32_t select_music_style = TEXT2_SELECT_MUSIC + 2;
+    uint16_t prompt_pal = roms.rom0.read8(&select_music_style);
+    prompt_pal = 0x80A0 | ((prompt_pal << 9) | ((prompt_pal >> 7) & 1));
+
+    draw_double_row_centered(
+        3,
+        "SELECT GAME MODE WITH VIEW BUTTONS",
+        prompt_pal);
+
+    // 0x8AA0 is the palette used by the enhanced song title when music notes
+    // are enabled. Use the same font/palette here, but deliberately omit notes.
+    draw_double_row_centered(5, mode_name, 0x8AA0);
+
+    // Keep the car-colour control visible but unobtrusive below the song title.
+    // This replaces the large block of helper text that previously covered the
+    // radio artwork.
+    ohud.blit_text_new(0, 14, "                                        ", OHud::GREY);
+    ohud.blit_text_new(16, 14, "COLOR", OHud::GREY);
+    draw_color_swatch(22, 14);
 }
 
 int OMusic::get_music_selected()
@@ -398,7 +447,14 @@ void OMusic::enable()
     else
         set_game_mode(Outrun::MODE_ORIGINAL);
 
-    menu_gear_state = oinputs.gear;
+    // For a physical LOW/HIGH cabinet shifter, track the raw LOW contact. This
+    // gives the music screen both edges of the lever movement reliably. Other
+    // gear modes continue to use the logical gear state or button edges below.
+    if (config.controls.gear == config.controls.GEAR_PRESS)
+        menu_gear_state = input.is_pressed(Input::GEAR1);
+    else
+        menu_gear_state = oinputs.gear;
+
     menu_gear_initialized = true;
     draw_game_options();
 }
@@ -516,31 +572,48 @@ void OMusic::check_start()
     else if (input.has_pressed(Input::VIEWPOINT))
         cycle_game_mode();
 
-    // Use the shifter as a colour selector only on this screen. A real arcade
-    // LOW/HIGH shifter naturally moves backwards/forwards through the palette;
-    // separate gear buttons and automatic setups get explicit previous/next.
-    if (config.controls.gear == config.controls.GEAR_SEPARATE ||
-        config.controls.gear == config.controls.GEAR_AUTO)
+    // Use the shifter as a colour selector only on this screen. Read the real
+    // cabinet LOW/HIGH contact directly so both lever directions are detected;
+    // the ordinary driving gear state is deliberately not used for that mode.
+    if (config.controls.gear == config.controls.GEAR_PRESS)
+    {
+        const bool low_now = input.is_pressed(Input::GEAR1);
+
+        if (!menu_gear_initialized)
+        {
+            menu_gear_state = low_now;
+            menu_gear_initialized = true;
+        }
+        else if (low_now != menu_gear_state)
+        {
+            // Moving into LOW steps backwards; moving into HIGH steps forwards.
+            cycle_car_color(low_now ? -1 : 1);
+            menu_gear_state = low_now;
+        }
+    }
+    else if (config.controls.gear == config.controls.GEAR_SEPARATE)
     {
         if (input.has_pressed(Input::GEAR1))
             cycle_car_color(-1);
         else if (input.has_pressed(Input::GEAR2))
             cycle_car_color(1);
     }
-    else
+    else if (config.controls.gear == config.controls.GEAR_BUTTON)
     {
-        const bool gear_now = oinputs.gear;
-
-        if (!menu_gear_initialized)
-        {
-            menu_gear_state = gear_now;
-            menu_gear_initialized = true;
-        }
-        else if (gear_now != menu_gear_state)
-        {
-            cycle_car_color(gear_now ? 1 : -1);
-            menu_gear_state = gear_now;
-        }
+        // A one-button shifter has no physical direction. The normal gear logic
+        // has already toggled oinputs.gear this frame, so alternate the colour
+        // direction in the same LOW/HIGH sense.
+        if (input.has_pressed(Input::GEAR1))
+            cycle_car_color(oinputs.gear ? 1 : -1);
+    }
+    else // GEAR_AUTO
+    {
+        // Automatic transmission normally has no shifter, but honour explicit
+        // gear bindings if the player configured them for menu use.
+        if (input.has_pressed(Input::GEAR1))
+            cycle_car_color(-1);
+        else if (input.has_pressed(Input::GEAR2))
+            cycle_car_color(1);
     }
 
     if (!ostats.credits || !input.has_pressed(Input::START))

--- a/src/main/engine/omusic.hpp
+++ b/src/main/engine/omusic.hpp
@@ -43,6 +43,15 @@ public:
     // outputs use this to blink only the matching VIEW 1/2/3 lamp.
     int get_game_mode() const { return game_mode_selected; }
 
+    // The Time Trial course selector can be cancelled back to the frontend.
+    // Clear the one-shot handoff so a later Time Trial cannot accidentally
+    // reuse the music selection from the cancelled run.
+    void cancel_time_trial_from_music()
+    {
+        return_from_time_trial = false;
+        skip_music_tick = false;
+    }
+
 private:
     // Modified Widescreen version of the Music Select Tilemap
     RomLoader* tilemap;

--- a/src/main/engine/omusic.hpp
+++ b/src/main/engine/omusic.hpp
@@ -39,6 +39,10 @@ public:
     // has no side effects on the wheel detent implementation.
     int get_music_position() const { return cursor_pos; }
 
+    // Selected game mode while the music screen is active. External cabinet
+    // outputs use this to blink only the matching VIEW 1/2/3 lamp.
+    int get_game_mode() const { return game_mode_selected; }
+
 private:
     // Modified Widescreen version of the Music Select Tilemap
     RomLoader* tilemap;
@@ -63,6 +67,22 @@ private:
     int16_t last_music_selected;
     int8_t preview_counter;
 
+    // Game mode chosen on the music-selection screen. VIEW cycles this value;
+    // VIEW1/2/3 select Original/Continuous/Time Trial directly.
+    int game_mode_selected;
+
+    // Gear/shifter state used to turn LOW/HIGH movement into previous/next
+    // Ferrari colour selection without affecting the in-race gear logic.
+    bool menu_gear_initialized;
+    bool menu_gear_state;
+
+    // Time Trial normally flows Track Select -> Music Select -> Race. When it
+    // was entered from this music screen we remember the chosen song and skip
+    // that second music screen after the course has been selected.
+    bool return_from_time_trial;
+    bool skip_music_tick;
+    int pending_music_selected;
+
     // Music-selector FFB tracking. The spring is made progressively stronger
     // when many tracks are present so closely spaced virtual detents remain
     // distinguishable.
@@ -85,6 +105,13 @@ private:
     int steering_for_track(int track) const;
     void apply_music_detent_ffb();
     void reset_music_detent_ffb();
+
+    void set_game_mode(int mode);
+    void cycle_game_mode();
+    void cycle_car_color(int direction);
+    void set_continuous_traffic_from_difficulty();
+    void draw_game_options();
+    void draw_color_swatch(uint16_t x, uint16_t y);
 };
 
 extern OMusic omusic;

--- a/src/main/engine/ooutputs.cpp
+++ b/src/main/engine/ooutputs.cpp
@@ -180,9 +180,10 @@ namespace
             video.write_text16(ohud.translate(x, 15), 0);
         }
 
-        // Put the instruction on exactly the same row and in exactly the same
-        // single-row font/palette as the original FREE PLAY text. Right-align
-        // it so FREE PLAY remains untouched on the left side of the screen.
+        // Reuse the exact single-row font and palette of FREE PLAY. The lower
+        // line shares the FREE PLAY row, while the short HI - LOW hint sits one
+        // row above it. Keeping both right-aligned makes the control hint read
+        // as one compact arcade-style block instead of a long sentence.
         uint32_t freeplay_record = TEXT1_FREEPLAY;
         const uint32_t freeplay_dst = roms.rom0.read32(&freeplay_record);
         roms.rom0.read16(&freeplay_record); // tile count
@@ -194,19 +195,32 @@ namespace
         const uint16_t freeplay_y =
             static_cast<uint16_t>(freeplay_relative / 0x80);
 
-        const char* text = "CHANGE CAR COLOR WITH GEAR";
-        const int length = 26;
-        const int x_start = 40 - length;
+        const char* line1 = "HI - LOW";
+        const char* line2 = "CHANGE COLOR";
+        const int line1_length = 8;
+        const int line2_length = 12;
+        const int line1_x = 40 - line1_length;
+        const int line2_x = 40 - line2_length;
+        const uint16_t line1_y = freeplay_y > 0 ? freeplay_y - 1 : freeplay_y;
 
-        // Only clear the right-hand portion. The original FREE PLAY text is
-        // redrawn by OHud on the left each frame and must remain untouched.
-        for (int x = x_start; x < 40; x++)
+        // Clear only the compact right-hand block. FREE PLAY on the left remains
+        // untouched and is still drawn by the original HUD code.
+        for (int x = line2_x; x < 40; x++)
+        {
+            video.write_text16(ohud.translate(x, line1_y), 0);
             video.write_text16(ohud.translate(x, freeplay_y), 0);
+        }
 
         ohud.blit_text_new(
-            static_cast<uint16_t>(x_start),
+            static_cast<uint16_t>(line1_x),
+            line1_y,
+            line1,
+            freeplay_pal);
+
+        ohud.blit_text_new(
+            static_cast<uint16_t>(line2_x),
             freeplay_y,
-            text,
+            line2,
             freeplay_pal);
 
         // Reuse the small Ferrari that normally drives across the course map.
@@ -224,10 +238,10 @@ namespace
         preview->shadow = roms.rom0p->read8(map_ferrari_entry + 2);
         preview->zoom = roms.rom0p->read8(map_ferrari_entry + 3);
 
-        // Mirror the FREE PLAY placement: preview the selected car just above
-        // the new right-hand instruction rather than in the middle of screen.
-        preview->x = 112;
-        preview->y = static_cast<int16_t>((freeplay_y * 8) - 12);
+        // Pull the preview in beside the compact two-line hint so the car and
+        // its control instruction form one visual group in the lower-right.
+        preview->x = 48;
+        preview->y = static_cast<int16_t>((freeplay_y * 8) - 4);
         preview->priority = 0x1FF;
         preview->road_priority = 0x1FF;
         preview->addr = outrun.adr.sprite_minicar_right;

--- a/src/main/engine/ooutputs.cpp
+++ b/src/main/engine/ooutputs.cpp
@@ -17,6 +17,7 @@
 #undef writeDigitalToConsole
 
 #include "main.hpp"
+#include "engine/omusic.hpp"
 #include "engine/oroad.hpp"
 #include "engine/ostats.hpp"
 #include "sdl2/input.hpp"
@@ -60,8 +61,9 @@ void OOutputs::writeDigitalToConsole()
         outrun.game_state >= GS_START1 &&
         outrun.game_state <= GS_INGAME;
 
-    // The single VIEW lamp is an availability lamp: steady on from the moment
-    // the car drives in until game-over begins. No blinking.
+    // During the race the single VIEW lamp remains the normal availability
+    // lamp. During music selection it becomes a mode-selection lamp and blinks
+    // in sync with the one matching VIEW1/2/3 lamp below.
     const bool view_lamp_active =
         outrun.game_state >= GS_START1 &&
         outrun.game_state < GS_INIT_GAMEOVER;
@@ -99,6 +101,15 @@ void OOutputs::writeDigitalToConsole()
         outrun.game_state >= GS_INIT_GAME &&
         outrun.game_state <= GS_BONUS;
 
+    // Music-select game mode indication. The traditional single VIEW lamp
+    // always blinks here, while only the lamp for the selected direct-view
+    // button blinks with it. The other two remain off.
+    const bool mode_lamp_blink =
+        music_selection &&
+        (outrun.tick_counter & BIT_4);
+
+    const int selected_game_mode = omusic.get_game_mode();
+
     const auto& settings = external_output_settings();
 
     external_outputs.update(
@@ -108,8 +119,16 @@ void OOutputs::writeDigitalToConsole()
         cannonball::state != cannonball::STATE_QUIT,
         (start_lamp_blink || start_lamp_ingame) ? 1 : 0,
         is_set(D_BRAKE_LAMP),
-        view_lamp_active ? 1 : 0,
-        (view_lamp_active && view == ORoad::VIEW_ORIGINAL) ? 1 : 0,
-        (view_lamp_active && view == ORoad::VIEW_ELEVATED) ? 1 : 0,
-        (view_lamp_active && view == ORoad::VIEW_INCAR) ? 1 : 0);
+        music_selection
+            ? (mode_lamp_blink ? 1 : 0)
+            : (view_lamp_active ? 1 : 0),
+        music_selection
+            ? ((mode_lamp_blink && selected_game_mode == Outrun::MODE_ORIGINAL) ? 1 : 0)
+            : ((view_lamp_active && view == ORoad::VIEW_ORIGINAL) ? 1 : 0),
+        music_selection
+            ? ((mode_lamp_blink && selected_game_mode == Outrun::MODE_CONT) ? 1 : 0)
+            : ((view_lamp_active && view == ORoad::VIEW_ELEVATED) ? 1 : 0),
+        music_selection
+            ? ((mode_lamp_blink && selected_game_mode == Outrun::MODE_TTRIAL) ? 1 : 0)
+            : ((view_lamp_active && view == ORoad::VIEW_INCAR) ? 1 : 0));
 }

--- a/src/main/engine/ooutputs.cpp
+++ b/src/main/engine/ooutputs.cpp
@@ -17,8 +17,11 @@
 #undef writeDigitalToConsole
 
 #include "main.hpp"
+#include "engine/oferrari.hpp"
+#include "engine/ohud.hpp"
 #include "engine/omusic.hpp"
 #include "engine/oroad.hpp"
+#include "engine/osprites.hpp"
 #include "engine/ostats.hpp"
 #include "engine/otraffic.hpp"
 #include "sdl2/input.hpp"
@@ -132,6 +135,88 @@ namespace
         outrun.custom_traffic = traffic;
         otraffic.set_custom_max_traffic(traffic);
     }
+
+    void draw_music_color_preview(bool music_selection)
+    {
+        if (!music_selection || outrun.game_state != GS_MUSIC)
+            return;
+
+        // Replace the temporary COLOR/swatch row drawn by OMusic with a proper
+        // arcade-style instruction. Reuse the exact font and palette from the
+        // original SELECT MUSIC BY STEERING ROM record.
+        uint32_t select_music_style = TEXT2_SELECT_MUSIC + 2;
+        uint16_t prompt_pal = roms.rom0.read8(&select_music_style);
+        prompt_pal = 0x80A0 | ((prompt_pal << 9) | ((prompt_pal >> 7) & 1));
+
+        const char* text = "CHANGE CAR COLOR WITH GEAR";
+        const int length = 26;
+        const int x_start = 20 - (length / 2);
+
+        for (int x = 0; x < 40; x++)
+        {
+            video.write_text16(ohud.translate(x, 14), 0);
+            video.write_text16(ohud.translate(x, 14) + 0x80, 0);
+        }
+
+        uint32_t dst_addr = ohud.translate(x_start, 14);
+        for (int i = 0; i < length; i++)
+        {
+            uint16_t c = static_cast<uint8_t>(text[i]);
+
+            if (c == ' ')
+            {
+                video.write_text16(&dst_addr, 0);
+                video.write_text16(0x7E + dst_addr, 0);
+            }
+            else
+            {
+                c = ((c - 'A') * 2) + prompt_pal;
+                video.write_text16(&dst_addr, c);
+                video.write_text16(0x7E + dst_addr, c + 1);
+            }
+        }
+
+        // Reuse the small Ferrari that normally drives across the course map.
+        // The map entry supplies its native size/anchor properties, while the
+        // palette is deliberately replaced by the same five Ferrari palettes
+        // used by the full-size in-game car.
+        const int preview_index = (OSprites::SPRITE_ENTRIES - 0x10) + 5;
+        oentry* preview = &osprites.jump_table[preview_index];
+        preview->init(preview_index);
+
+        const uint32_t map_ferrari_entry =
+            outrun.adr.sprite_coursemap + (25 * 20);
+
+        preview->draw_props = roms.rom0p->read8(map_ferrari_entry + 1);
+        preview->shadow = roms.rom0p->read8(map_ferrari_entry + 2);
+        preview->zoom = roms.rom0p->read8(map_ferrari_entry + 3);
+        preview->x = 0;
+        preview->y = 154;
+        preview->priority = 0x1FF;
+        preview->road_priority = 0x1FF;
+        preview->addr = outrun.adr.sprite_minicar_right;
+
+        static const uint16_t CAR_PALETTES[] =
+        {
+            OFerrari::PAL_RED,
+            OFerrari::PAL_BLUE,
+            OFerrari::PAL_YELLOW,
+            OFerrari::PAL_GREEN,
+            OFerrari::PAL_CYAN,
+        };
+
+        int color = config.engine.car_pal;
+        if (color < 0 || color >= 5)
+            color = 0;
+
+        preview->pal_src = CAR_PALETTES[color];
+        osprites.map_palette(preview);
+
+        // writeDigitalToConsole() runs after the current engine frame has been
+        // assembled. Queue the preview here and it joins the Music Select sprite
+        // list on the following frame; doing this every frame keeps it stable.
+        osprites.do_spr_order_shadows(preview);
+    }
 }
 
 void OOutputs::writeDigitalToConsole()
@@ -148,6 +233,9 @@ void OOutputs::writeDigitalToConsole()
     // This is intentionally independent of whether external outputs are enabled;
     // this method is already called every engine tick by main.cpp.
     sync_continuous_traffic_to_difficulty();
+
+    // Draw the car-colour instruction and queue the small map Ferrari preview.
+    draw_music_color_preview(music_selection);
 
     // Preserve the original SmartyPi console output path exactly as before.
     writeDigitalToConsole_base();

--- a/src/main/engine/ooutputs.cpp
+++ b/src/main/engine/ooutputs.cpp
@@ -181,9 +181,8 @@ namespace
         }
 
         // Reuse the exact single-row font and palette of FREE PLAY. The lower
-        // line shares the FREE PLAY row, while the short HI - LOW hint sits one
-        // row above it. Keeping both right-aligned makes the control hint read
-        // as one compact arcade-style block instead of a long sentence.
+        // line shares the FREE PLAY row, while LOW - HI sits one row above it.
+        // Both lines use the same centre point so the block stays symmetrical.
         uint32_t freeplay_record = TEXT1_FREEPLAY;
         const uint32_t freeplay_dst = roms.rom0.read32(&freeplay_record);
         roms.rom0.read16(&freeplay_record); // tile count
@@ -195,12 +194,12 @@ namespace
         const uint16_t freeplay_y =
             static_cast<uint16_t>(freeplay_relative / 0x80);
 
-        const char* line1 = "HI - LOW";
+        const char* line1 = "LOW - HI";
         const char* line2 = "CHANGE COLOR";
         const int line1_length = 8;
         const int line2_length = 12;
-        const int line1_x = 40 - line1_length;
         const int line2_x = 40 - line2_length;
+        const int line1_x = line2_x + ((line2_length - line1_length) / 2);
         const uint16_t line1_y = freeplay_y > 0 ? freeplay_y - 1 : freeplay_y;
 
         // Clear only the compact right-hand block. FREE PLAY on the left remains
@@ -238,10 +237,11 @@ namespace
         preview->shadow = roms.rom0p->read8(map_ferrari_entry + 2);
         preview->zoom = roms.rom0p->read8(map_ferrari_entry + 3);
 
-        // Pull the preview in beside the compact two-line hint so the car and
-        // its control instruction form one visual group in the lower-right.
-        preview->x = 48;
-        preview->y = static_cast<int16_t>((freeplay_y * 8) - 4);
+        // Centre the preview directly above the '-' in LOW - HI. Sprite X is
+        // relative to the 320-pixel playfield centre, while text X is in tiles.
+        const int dash_x = line1_x + 4;
+        preview->x = static_cast<int16_t>(((dash_x * 8) + 4) - 160);
+        preview->y = static_cast<int16_t>((line1_y * 8) - 8);
         preview->priority = 0x1FF;
         preview->road_priority = 0x1FF;
         preview->addr = outrun.adr.sprite_minicar_right;

--- a/src/main/engine/ooutputs.cpp
+++ b/src/main/engine/ooutputs.cpp
@@ -20,6 +20,7 @@
 #include "engine/omusic.hpp"
 #include "engine/oroad.hpp"
 #include "engine/ostats.hpp"
+#include "engine/otraffic.hpp"
 #include "sdl2/input.hpp"
 
 namespace
@@ -122,8 +123,14 @@ namespace
         else if (stage_group > 4)
             stage_group = 4;
 
-        outrun.custom_traffic =
+        const uint8_t traffic =
             ORIGINAL_TRAFFIC[(difficulty * 5) + stage_group];
+
+        // Keep both values synchronized. OTraffic::set_max_traffic() samples
+        // custom_traffic at checkpoints; updating max_traffic too ensures the
+        // new stage-group value takes effect immediately on that same frame.
+        outrun.custom_traffic = traffic;
+        otraffic.set_custom_max_traffic(traffic);
     }
 }
 

--- a/src/main/engine/ooutputs.cpp
+++ b/src/main/engine/ooutputs.cpp
@@ -34,6 +34,7 @@ namespace
     bool direct_view2_old = false;
     bool direct_view3_old = false;
     int music_mode_synced = -1;
+    bool music_color_initialized = false;
 
     void handle_direct_view_buttons(bool controls_active)
     {
@@ -136,45 +137,65 @@ namespace
         otraffic.set_custom_max_traffic(traffic);
     }
 
+    void sync_music_car_color(bool music_selection)
+    {
+        if (!music_selection)
+        {
+            music_color_initialized = false;
+            return;
+        }
+
+        if (!music_color_initialized)
+        {
+            // Every new arcade Music Select starts from the canonical red
+            // Ferrari. Shifter changes are deliberately per-run choices.
+            config.engine.car_pal = 0;
+            music_color_initialized = true;
+        }
+    }
+
     void draw_music_color_preview(bool music_selection)
     {
         if (!music_selection || outrun.game_state != GS_MUSIC)
             return;
 
-        // Replace the temporary COLOR/swatch row drawn by OMusic with a proper
-        // arcade-style instruction. Reuse the exact font and palette from the
-        // original SELECT MUSIC BY STEERING ROM record.
-        uint32_t select_music_style = TEXT2_SELECT_MUSIC + 2;
-        uint16_t prompt_pal = roms.rom0.read8(&select_music_style);
-        prompt_pal = 0x80A0 | ((prompt_pal << 9) | ((prompt_pal >> 7) & 1));
-
-        const char* text = "CHANGE CAR COLOR WITH GEAR";
-        const int length = 26;
-        const int x_start = 20 - (length / 2);
-
+        // OMusic used an experimental centre-screen COLOR row while this
+        // feature was being prototyped. Clear both affected rows so the final
+        // presentation leaves the centre of the original Music Select clean.
         for (int x = 0; x < 40; x++)
         {
             video.write_text16(ohud.translate(x, 14), 0);
-            video.write_text16(ohud.translate(x, 14) + 0x80, 0);
+            video.write_text16(ohud.translate(x, 15), 0);
         }
 
-        uint32_t dst_addr = ohud.translate(x_start, 14);
-        for (int i = 0; i < length; i++)
-        {
-            uint16_t c = static_cast<uint8_t>(text[i]);
+        // Put the instruction on exactly the same row and in exactly the same
+        // single-row font/palette as the original FREE PLAY text. Right-align
+        // it so FREE PLAY remains untouched on the left side of the screen.
+        uint32_t freeplay_record = TEXT1_FREEPLAY;
+        const uint32_t freeplay_dst = roms.rom0.read32(&freeplay_record);
+        roms.rom0.read16(&freeplay_record); // tile count
+        const uint16_t freeplay_data = roms.rom0.read16(&freeplay_record);
+        const uint16_t freeplay_pal = (freeplay_data >> 8) & 0xFF;
 
-            if (c == ' ')
-            {
-                video.write_text16(&dst_addr, 0);
-                video.write_text16(0x7E + dst_addr, 0);
-            }
-            else
-            {
-                c = ((c - 'A') * 2) + prompt_pal;
-                video.write_text16(&dst_addr, c);
-                video.write_text16(0x7E + dst_addr, c + 1);
-            }
-        }
+        const uint32_t freeplay_relative =
+            (freeplay_dst - 0x110030) & 0x0FFF;
+        const uint16_t freeplay_y =
+            static_cast<uint16_t>(freeplay_relative / 0x80);
+
+        const char* text = "CHANGE CAR COLOR WITH GEAR";
+        const int length = 26;
+        const int x_start = 40 - length;
+
+        // Only clear the right-hand portion. The original FREE PLAY text is
+        // redrawn by OHud on the left each frame and must remain untouched.
+        for (int x = x_start; x < 40; x++)
+            video.write_text16(ohud.translate(x, freeplay_y), 0);
+
+        ohud.blit_text_new(
+            static_cast<uint16_t>(x_start),
+            freeplay_y,
+            text,
+            freeplay_pal);
 
         // Reuse the small Ferrari that normally drives across the course map.
         // The map entry supplies its native size/anchor properties, while the
@@ -190,8 +211,11 @@ namespace
         preview->draw_props = roms.rom0p->read8(map_ferrari_entry + 1);
         preview->shadow = roms.rom0p->read8(map_ferrari_entry + 2);
         preview->zoom = roms.rom0p->read8(map_ferrari_entry + 3);
-        preview->x = 0;
-        preview->y = 154;
+
+        // Mirror the FREE PLAY placement: preview the selected car just above
+        // the new right-hand instruction rather than in the middle of screen.
+        preview->x = 112;
+        preview->y = static_cast<int16_t>((freeplay_y * 8) - 12);
         preview->priority = 0x1FF;
         preview->road_priority = 0x1FF;
         preview->addr = outrun.adr.sprite_minicar_right;
@@ -222,8 +246,9 @@ namespace
 void OOutputs::writeDigitalToConsole()
 {
     const bool music_selection =
-        outrun.game_state == GS_INIT_MUSIC ||
-        outrun.game_state == GS_MUSIC;
+        cannonball::state == cannonball::STATE_GAME &&
+        (outrun.game_state == GS_INIT_MUSIC ||
+         outrun.game_state == GS_MUSIC);
 
     // Keep the visible Music Select choice and the underlying mode in sync,
     // including the original automatic Music Select timeout behaviour.
@@ -233,6 +258,10 @@ void OOutputs::writeDigitalToConsole()
     // This is intentionally independent of whether external outputs are enabled;
     // this method is already called every engine tick by main.cpp.
     sync_continuous_traffic_to_difficulty();
+
+    // New runs always begin from the red Ferrari, then allow a temporary colour
+    // choice with the shifter for that run.
+    sync_music_car_color(music_selection);
 
     // Draw the car-colour instruction and queue the small map Ferrari preview.
     draw_music_color_preview(music_selection);

--- a/src/main/engine/ooutputs.cpp
+++ b/src/main/engine/ooutputs.cpp
@@ -50,10 +50,47 @@ namespace
         direct_view2_old = view2;
         direct_view3_old = view3;
     }
+
+    void sync_continuous_traffic_to_difficulty()
+    {
+        if (outrun.cannonball_mode != Outrun::MODE_CONT)
+            return;
+
+        // Use the exact same stage/difficulty table as original OutRun. The
+        // Continuous route visits all 15 stages, but stage_lookup_off / 8 still
+        // identifies the original stage group (1..5) for traffic purposes.
+        static const uint8_t ORIGINAL_TRAFFIC[] =
+        {
+            2, 2, 3, 4, 5, // Easy
+            3, 4, 5, 6, 7, // Normal
+            4, 5, 6, 7, 8, // Hard
+            5, 6, 7, 8, 8, // Hardest
+        };
+
+        int difficulty = config.engine.dip_traffic;
+        if (difficulty < 0)
+            difficulty = 0;
+        else if (difficulty > 3)
+            difficulty = 3;
+
+        int stage_group = oroad.stage_lookup_off / 8;
+        if (stage_group < 0)
+            stage_group = 0;
+        else if (stage_group > 4)
+            stage_group = 4;
+
+        outrun.custom_traffic =
+            ORIGINAL_TRAFFIC[(difficulty * 5) + stage_group];
+    }
 }
 
 void OOutputs::writeDigitalToConsole()
 {
+    // Keep Continuous traffic tied to the normal OutRun difficulty setting.
+    // This is intentionally independent of whether external outputs are enabled;
+    // this method is already called every engine tick by main.cpp.
+    sync_continuous_traffic_to_difficulty();
+
     // Preserve the original SmartyPi console output path exactly as before.
     writeDigitalToConsole_base();
 

--- a/src/main/engine/ooutputs.cpp
+++ b/src/main/engine/ooutputs.cpp
@@ -142,6 +142,18 @@ namespace
         if (!music_selection)
         {
             music_color_initialized = false;
+
+            // Car-colour selection belongs to the player's next run only.
+            // Attract/demo mode must always use the canonical red Ferrari,
+            // regardless of the colour chosen for the previous game.
+            if (cannonball::state == cannonball::STATE_GAME &&
+                (outrun.game_state == GS_INIT ||
+                 outrun.game_state == GS_ATTRACT))
+            {
+                config.engine.car_pal = 0;
+                oferrari.ferrari_pal = OFerrari::PAL_RED;
+            }
+
             return;
         }
 
@@ -260,7 +272,8 @@ void OOutputs::writeDigitalToConsole()
     sync_continuous_traffic_to_difficulty();
 
     // New runs always begin from the red Ferrari, then allow a temporary colour
-    // choice with the shifter for that run.
+    // choice with the shifter for that run. Attract mode is also forced back to
+    // red here so a previous player colour never leaks into the demo sequence.
     sync_music_car_color(music_selection);
 
     // Draw the car-colour instruction and queue the small map Ferrari preview.

--- a/src/main/engine/ooutputs.cpp
+++ b/src/main/engine/ooutputs.cpp
@@ -29,6 +29,7 @@ namespace
     bool direct_view1_old = false;
     bool direct_view2_old = false;
     bool direct_view3_old = false;
+    int music_mode_synced = -1;
 
     void handle_direct_view_buttons(bool controls_active)
     {
@@ -49,6 +50,48 @@ namespace
         direct_view1_old = view1;
         direct_view2_old = view2;
         direct_view3_old = view3;
+    }
+
+    void sync_music_selection_mode(bool music_selection)
+    {
+        if (!music_selection)
+        {
+            music_mode_synced = -1;
+            return;
+        }
+
+        const int selected = omusic.get_game_mode();
+
+        // A newly selected Time Trial still needs the course map. Keep the
+        // music-selection timer alive so the normal timeout cannot start a
+        // stale/unselected Time Trial track. A legacy Time Trial has already
+        // chosen its course, so its normal timer behaviour is preserved.
+        if (selected == Outrun::MODE_TTRIAL &&
+            outrun.cannonball_mode != Outrun::MODE_TTRIAL)
+        {
+            ostats.time_counter = config.sound.music_timer;
+            ostats.frame_counter = ostats.frame_reset;
+            music_mode_synced = selected;
+            return;
+        }
+
+        if (selected != Outrun::MODE_ORIGINAL &&
+            selected != Outrun::MODE_CONT)
+        {
+            music_mode_synced = selected;
+            return;
+        }
+
+        // Keep the underlying engine mode aligned with what the player sees.
+        // This also makes the original Music Select auto-timeout launch the
+        // selected Original/Continuous mode rather than whichever mode booted.
+        outrun.cannonball_mode = selected;
+
+        if (selected != music_mode_synced)
+        {
+            config.load_scores(selected == Outrun::MODE_ORIGINAL);
+            music_mode_synced = selected;
+        }
     }
 
     void sync_continuous_traffic_to_difficulty()
@@ -86,6 +129,14 @@ namespace
 
 void OOutputs::writeDigitalToConsole()
 {
+    const bool music_selection =
+        outrun.game_state == GS_INIT_MUSIC ||
+        outrun.game_state == GS_MUSIC;
+
+    // Keep the visible Music Select choice and the underlying mode in sync,
+    // including the original automatic Music Select timeout behaviour.
+    sync_music_selection_mode(music_selection);
+
     // Keep Continuous traffic tied to the normal OutRun difficulty setting.
     // This is intentionally independent of whether external outputs are enabled;
     // this method is already called every engine tick by main.cpp.
@@ -120,10 +171,6 @@ void OOutputs::writeDigitalToConsole()
 
     const bool press_start_available =
         config.engine.freeplay || ostats.credits > 0;
-
-    const bool music_selection =
-        outrun.game_state == GS_INIT_MUSIC ||
-        outrun.game_state == GS_MUSIC;
 
     // Blink during attract PRESS START and throughout music selection. The
     // attract phase uses the same BIT_4 timing as OHud::draw_insert_coin().

--- a/src/main/engine/otraffic.hpp
+++ b/src/main/engine/otraffic.hpp
@@ -45,6 +45,11 @@ public:
     void traffic_logic();
     void traffic_sound();
 
+    // Continuous mode can mirror the original OutRun difficulty table after
+    // its stage lookup advances. Keep the actual spawn cap synchronized with
+    // the public custom_traffic value without waiting for another checkpoint.
+    void set_custom_max_traffic(uint8_t value) { max_traffic = value; }
+
 private:
 
 	// -------------------------------------------------------------------------

--- a/src/main/frontend/menu.hpp
+++ b/src/main/frontend/menu.hpp
@@ -137,6 +137,23 @@ public:
     Menu() = default;
     ~Menu() override = default;
 
+    // Populate the existing menus, then remove the now-obsolete Continuous
+    // traffic selector. Continuous traffic follows the normal OutRun DIP
+    // difficulty automatically; the legacy config value remains loadable for
+    // backwards compatibility but is no longer presented to the player.
+    void populate()
+    {
+        MenuBase::populate();
+
+        for (auto it = menu_cont.begin(); it != menu_cont.end(); )
+        {
+            if (it->rfind("TRAFFIC ", 0) == 0)
+                it = menu_cont.erase(it);
+            else
+                ++it;
+        }
+    }
+
     // Wrapper hook used to keep analog steering from moving normal menu
     // cursors while leaving in-game steering untouched.
     void tick();

--- a/src/main/frontend/menu.hpp
+++ b/src/main/frontend/menu.hpp
@@ -13,9 +13,10 @@
 #include <vector>
 #include <string>
 #include "stdint.hpp"
+#include "main.hpp"
+#include "frontend/ttrial.hpp"
 
 class CabDiag;
-class TTrial;
 
 // Base menu implementation retained from the current CannonBall-SE code.
 // Menu derives from this only so the external-output feature can extend the
@@ -139,6 +140,16 @@ public:
     // Wrapper hook used to keep analog steering from moving normal menu
     // cursors while leaving in-game steering untouched.
     void tick();
+
+    // Enter the existing Time Trial course selector from the in-game music
+    // screen. TTrial itself still owns track/lap/traffic setup; once a track is
+    // confirmed the normal frontend path starts the engine again.
+    void start_time_trial_from_music()
+    {
+        state = STATE_TTRIAL;
+        ttrial->init();
+        cannonball::state = cannonball::STATE_MENU;
+    }
 
 protected:
     void populate_controls() override;

--- a/src/main/frontend/ttrial.cpp
+++ b/src/main/frontend/ttrial.cpp
@@ -12,6 +12,7 @@
 
 #include "engine/ohud.hpp"
 #include "engine/oinputs.hpp"
+#include "engine/omusic.hpp"
 #include "engine/outils.hpp"
 #include "engine/omap.hpp"
 #include "engine/ostats.hpp"
@@ -75,6 +76,7 @@ int TTrial::tick()
             {
                 if (input.has_pressed(Input::MENU))
                 {
+                    omusic.cancel_time_trial_from_music();
                     return BACK_TO_MENU;
                 }
                 else if (input.has_pressed(Input::LEFT) || oinputs.is_analog_l())


### PR DESCRIPTION
## Summary
- add Original / Continuous / Time Trial selection directly to the Music Select screen
- support single VIEW cycling and direct VIEW1 / VIEW2 / VIEW3 selection
- blink the single VIEW lamp plus only the currently selected direct-view lamp during Music Select
- restore normal view-lamp camera behavior once driving starts
- add per-run Ferrari colour selection with the shifter, always starting from red
- show the selected colour using the original mini-Ferrari course-map sprite
- keep the Ferrari red in attract/demo mode
- route Time Trial through the existing course selector while preserving the selected music
- make Continuous traffic follow the normal OutRun difficulty and stage scaling
- hide the obsolete standalone Continuous traffic option while retaining config compatibility

## Controls
- VIEW: cycle Original -> Continuous -> Time Trial
- VIEW1: Original
- VIEW2: Continuous
- VIEW3: Time Trial
- shifter LOW/HIGH: previous/next car colour
- START: confirm

## Music Select UI
- game-mode prompt uses the original SELECT MUSIC BY STEERING style
- selected mode uses the song-title style
- compact LOW - HI / CHANGE COLOR hint uses the FREE PLAY style
- mini Ferrari previews the currently selected colour

Runtime-tested during development before merge.