### PR TITLE
Interactive attract-mode view lamps

### DIFF
--- a/src/main/engine/ooutputs.cpp
+++ b/src/main/engine/ooutputs.cpp
@@ -333,6 +333,63 @@ void OOutputs::writeDigitalToConsole()
 
     const uint8_t view = oroad.get_view_mode();
 
+    // Mirror only the existing enhanced-attract automatic timer. This lets the
+    // lamp intro distinguish a genuine automatic return to ORIGINAL from any
+    // manual VIEW/VIEW1/VIEW2/VIEW3 change without modifying the view sequence.
+    static bool attract_sequence_tracking = false;
+    static int attract_sequence_counter = 0;
+    static uint8_t attract_sequence_view = 0;
+    static bool attract_original_intro = false;
+    static uint32_t attract_original_intro_start = 0;
+
+    if (enhanced_attract_driving)
+    {
+        if (!attract_sequence_tracking)
+        {
+            attract_sequence_tracking = true;
+            attract_sequence_counter = outrun.tick_frame ? 1 : 0;
+            attract_sequence_view = 0;
+            attract_original_intro = false;
+        }
+        else if (outrun.tick_frame && ++attract_sequence_counter > 240)
+        {
+            attract_sequence_counter = 0;
+            if (++attract_sequence_view > 2)
+                attract_sequence_view = 0;
+
+            // Only the automatic sequence can arm this intro. Manual changes
+            // never alter attract_sequence_view and therefore never trigger it.
+            if (attract_sequence_view == 0)
+            {
+                attract_original_intro = true;
+                attract_original_intro_start = outrun.tick_counter;
+            }
+        }
+    }
+    else
+    {
+        attract_sequence_tracking = false;
+        attract_sequence_counter = 0;
+        attract_sequence_view = 0;
+        attract_original_intro = false;
+    }
+
+    // If the player manually leaves ORIGINAL while the automatic return intro
+    // is running, cancel it immediately rather than flashing the wrong view.
+    if (attract_original_intro && view != ORoad::VIEW_ORIGINAL)
+        attract_original_intro = false;
+
+    uint32_t attract_original_intro_elapsed = 0;
+    if (attract_original_intro)
+    {
+        attract_original_intro_elapsed =
+            outrun.tick_counter - attract_original_intro_start;
+
+        // Three complete blinks: 16 ticks on + 16 ticks off, repeated 3 times.
+        if (attract_original_intro_elapsed >= 96)
+            attract_original_intro = false;
+    }
+
     // MAMEHooker START lamp behaviour is deliberately cabinet-oriented rather
     // than tied to the original D_START_LAMP bit. In particular, CannonBall's
     // freeplay PRESS START text does not set the original hardware bit.
@@ -365,30 +422,45 @@ void OOutputs::writeDigitalToConsole()
         music_selection &&
         (outrun.tick_counter & BIT_4);
 
-    // Custom attract views use the same blink cadence as START. The original
-    // view gets a faster four-step ping-pong chase across VIEW1/2/3 instead:
-    // 1 -> 2 -> 3 -> 2 -> ... . Each step lasts 8 ticks, exactly half the
-    // 16-tick START lamp phase, so the movement is twice as fast.
+    // Custom attract views blink their matching button at the START-lamp rate.
     const bool attract_custom_view_blink =
         enhanced_attract_driving &&
         (outrun.tick_counter & BIT_4);
 
-    const uint8_t attract_chase_phase =
+    // An automatic return to ORIGINAL first flashes all three buttons three
+    // times. Afterwards the faster ping-pong chase restarts from VIEW1.
+    const bool attract_original_intro_lit =
+        attract_original_intro &&
+        (((attract_original_intro_elapsed >> 4) & 1) == 0);
+
+    uint8_t attract_chase_phase =
         static_cast<uint8_t>((outrun.tick_counter >> 3) & 3);
 
-    const bool attract_chase_view1 =
+    if (view == ORoad::VIEW_ORIGINAL &&
+        !attract_original_intro &&
+        attract_original_intro_start != 0)
+    {
+        const uint32_t chase_elapsed =
+            outrun.tick_counter - attract_original_intro_start - 96;
+        attract_chase_phase =
+            static_cast<uint8_t>((chase_elapsed >> 3) & 3);
+    }
+
+    const bool attract_chase_active =
         enhanced_attract_driving &&
         view == ORoad::VIEW_ORIGINAL &&
+        !attract_original_intro;
+
+    const bool attract_chase_view1 =
+        attract_chase_active &&
         attract_chase_phase == 0;
 
     const bool attract_chase_view2 =
-        enhanced_attract_driving &&
-        view == ORoad::VIEW_ORIGINAL &&
+        attract_chase_active &&
         (attract_chase_phase == 1 || attract_chase_phase == 3);
 
     const bool attract_chase_view3 =
-        enhanced_attract_driving &&
-        view == ORoad::VIEW_ORIGINAL &&
+        attract_chase_active &&
         attract_chase_phase == 2;
 
     const int selected_game_mode = omusic.get_game_mode();
@@ -410,20 +482,22 @@ void OOutputs::writeDigitalToConsole()
         music_selection
             ? ((mode_lamp_blink && selected_game_mode == Outrun::MODE_ORIGINAL) ? 1 : 0)
             : (enhanced_attract_driving
-                ? (attract_chase_view1 ? 1 : 0)
+                ? ((view == ORoad::VIEW_ORIGINAL)
+                    ? ((attract_original_intro_lit || attract_chase_view1) ? 1 : 0)
+                    : 0)
                 : ((view_lamp_active && view == ORoad::VIEW_ORIGINAL) ? 1 : 0)),
         music_selection
             ? ((mode_lamp_blink && selected_game_mode == Outrun::MODE_CONT) ? 1 : 0)
             : (enhanced_attract_driving
                 ? ((view == ORoad::VIEW_ORIGINAL)
-                    ? (attract_chase_view2 ? 1 : 0)
+                    ? ((attract_original_intro_lit || attract_chase_view2) ? 1 : 0)
                     : ((view == ORoad::VIEW_ELEVATED && attract_custom_view_blink) ? 1 : 0))
                 : ((view_lamp_active && view == ORoad::VIEW_ELEVATED) ? 1 : 0)),
         music_selection
             ? ((mode_lamp_blink && selected_game_mode == Outrun::MODE_TTRIAL) ? 1 : 0)
             : (enhanced_attract_driving
                 ? ((view == ORoad::VIEW_ORIGINAL)
-                    ? (attract_chase_view3 ? 1 : 0)
+                    ? ((attract_original_intro_lit || attract_chase_view3) ? 1 : 0)
                     : ((view == ORoad::VIEW_INCAR && attract_custom_view_blink) ? 1 : 0))
                 : ((view_lamp_active && view == ORoad::VIEW_INCAR) ? 1 : 0)));
 }

--- a/src/main/engine/ooutputs.cpp
+++ b/src/main/engine/ooutputs.cpp
@@ -325,8 +325,8 @@ void OOutputs::writeDigitalToConsole()
 
     // During the race the single VIEW lamp remains the normal availability
     // lamp. During music selection it becomes a mode-selection lamp. During
-    // enhanced attract driving it blinks together with the currently selected
-    // direct-view lamp instead of remaining steadily lit.
+    // enhanced attract driving the dedicated VIEW1/2/3 lamps provide the show,
+    // so the legacy single VIEW lamp stays off there.
     const bool view_lamp_active =
         outrun.game_state >= GS_START1 &&
         outrun.game_state < GS_INIT_GAMEOVER;
@@ -365,12 +365,31 @@ void OOutputs::writeDigitalToConsole()
         music_selection &&
         (outrun.tick_counter & BIT_4);
 
-    // Enhanced attract mode uses the same cabinet-friendly blink cadence. This
-    // is intentionally GS_ATTRACT-only, so Best OutRunners and the logo screen
-    // leave all view lamps off while the START lamp keeps its existing logic.
-    const bool attract_view_lamp_blink =
+    // Custom attract views use the same blink cadence as START. The original
+    // view gets a faster four-step ping-pong chase across VIEW1/2/3 instead:
+    // 1 -> 2 -> 3 -> 2 -> ... . Each step lasts 8 ticks, exactly half the
+    // 16-tick START lamp phase, so the movement is twice as fast.
+    const bool attract_custom_view_blink =
         enhanced_attract_driving &&
         (outrun.tick_counter & BIT_4);
+
+    const uint8_t attract_chase_phase =
+        static_cast<uint8_t>((outrun.tick_counter >> 3) & 3);
+
+    const bool attract_chase_view1 =
+        enhanced_attract_driving &&
+        view == ORoad::VIEW_ORIGINAL &&
+        attract_chase_phase == 0;
+
+    const bool attract_chase_view2 =
+        enhanced_attract_driving &&
+        view == ORoad::VIEW_ORIGINAL &&
+        (attract_chase_phase == 1 || attract_chase_phase == 3);
+
+    const bool attract_chase_view3 =
+        enhanced_attract_driving &&
+        view == ORoad::VIEW_ORIGINAL &&
+        attract_chase_phase == 2;
 
     const int selected_game_mode = omusic.get_game_mode();
 
@@ -386,21 +405,25 @@ void OOutputs::writeDigitalToConsole()
         music_selection
             ? (mode_lamp_blink ? 1 : 0)
             : (enhanced_attract_driving
-                ? (attract_view_lamp_blink ? 1 : 0)
+                ? 0
                 : (view_lamp_active ? 1 : 0)),
         music_selection
             ? ((mode_lamp_blink && selected_game_mode == Outrun::MODE_ORIGINAL) ? 1 : 0)
             : (enhanced_attract_driving
-                ? ((attract_view_lamp_blink && view == ORoad::VIEW_ORIGINAL) ? 1 : 0)
+                ? (attract_chase_view1 ? 1 : 0)
                 : ((view_lamp_active && view == ORoad::VIEW_ORIGINAL) ? 1 : 0)),
         music_selection
             ? ((mode_lamp_blink && selected_game_mode == Outrun::MODE_CONT) ? 1 : 0)
             : (enhanced_attract_driving
-                ? ((attract_view_lamp_blink && view == ORoad::VIEW_ELEVATED) ? 1 : 0)
+                ? ((view == ORoad::VIEW_ORIGINAL)
+                    ? (attract_chase_view2 ? 1 : 0)
+                    : ((view == ORoad::VIEW_ELEVATED && attract_custom_view_blink) ? 1 : 0))
                 : ((view_lamp_active && view == ORoad::VIEW_ELEVATED) ? 1 : 0)),
         music_selection
             ? ((mode_lamp_blink && selected_game_mode == Outrun::MODE_TTRIAL) ? 1 : 0)
             : (enhanced_attract_driving
-                ? ((attract_view_lamp_blink && view == ORoad::VIEW_INCAR) ? 1 : 0)
+                ? ((view == ORoad::VIEW_ORIGINAL)
+                    ? (attract_chase_view3 ? 1 : 0)
+                    : ((view == ORoad::VIEW_INCAR && attract_custom_view_blink) ? 1 : 0))
                 : ((view_lamp_active && view == ORoad::VIEW_INCAR) ? 1 : 0)));
 }

--- a/src/main/engine/ooutputs.cpp
+++ b/src/main/engine/ooutputs.cpp
@@ -355,7 +355,8 @@ void OOutputs::writeDigitalToConsole()
     static uint8_t attract_sequence_view = 0;
     static bool attract_current_view_automatic = true;
     static bool attract_original_intro = false;
-    static uint32_t attract_original_effect_start = 0;
+    static uint32_t attract_original_intro_start = 0;
+    static uint32_t attract_original_chase_start = 0;
 
     if (enhanced_attract_driving)
     {
@@ -368,7 +369,8 @@ void OOutputs::writeDigitalToConsole()
             attract_sequence_view = 0;
             attract_current_view_automatic = true;
             attract_original_intro = false;
-            attract_original_effect_start = outrun.tick_counter;
+            attract_original_intro_start = 0;
+            attract_original_chase_start = outrun.tick_counter;
         }
         else if (outrun.tick_frame && ++attract_sequence_counter > 240)
         {
@@ -387,12 +389,14 @@ void OOutputs::writeDigitalToConsole()
                 // Only an automatic return to ORIGINAL gets the three-flash
                 // intro and subsequent ping-pong chase.
                 attract_original_intro = true;
-                attract_original_effect_start = outrun.tick_counter;
+                attract_original_intro_start = outrun.tick_counter;
+                attract_original_chase_start = outrun.tick_counter + 48;
             }
             else
             {
                 attract_original_intro = false;
-                attract_original_effect_start = 0;
+                attract_original_intro_start = 0;
+                attract_original_chase_start = 0;
             }
         }
 
@@ -402,7 +406,8 @@ void OOutputs::writeDigitalToConsole()
         {
             attract_current_view_automatic = false;
             attract_original_intro = false;
-            attract_original_effect_start = 0;
+            attract_original_intro_start = 0;
+            attract_original_chase_start = 0;
         }
     }
     else
@@ -412,14 +417,15 @@ void OOutputs::writeDigitalToConsole()
         attract_sequence_view = 0;
         attract_current_view_automatic = true;
         attract_original_intro = false;
-        attract_original_effect_start = 0;
+        attract_original_intro_start = 0;
+        attract_original_chase_start = 0;
     }
 
     uint32_t attract_original_intro_elapsed = 0;
     if (attract_original_intro)
     {
         attract_original_intro_elapsed =
-            outrun.tick_counter - attract_original_effect_start;
+            outrun.tick_counter - attract_original_intro_start;
 
         // All view-lamp effects run twice as fast as START: 8 ticks on,
         // 8 ticks off. Three complete flashes therefore take 48 ticks.
@@ -473,20 +479,8 @@ void OOutputs::writeDigitalToConsole()
         view == ORoad::VIEW_ORIGINAL &&
         !attract_original_intro)
     {
-        uint32_t chase_elapsed = 0;
-        if (attract_original_effect_start != 0)
-        {
-            chase_elapsed = outrun.tick_counter - attract_original_effect_start;
-            if (chase_elapsed >= 48)
-                chase_elapsed -= 48;
-            else if (attract_original_effect_start != outrun.tick_counter)
-                chase_elapsed = 0;
-        }
-        else
-        {
-            chase_elapsed = outrun.tick_counter;
-        }
-
+        const uint32_t chase_elapsed =
+            outrun.tick_counter - attract_original_chase_start;
         attract_chase_phase =
             static_cast<uint8_t>((chase_elapsed >> 3) & 3);
     }

--- a/src/main/engine/ooutputs.cpp
+++ b/src/main/engine/ooutputs.cpp
@@ -350,6 +350,7 @@ void OOutputs::writeDigitalToConsole()
             attract_sequence_counter = outrun.tick_frame ? 1 : 0;
             attract_sequence_view = 0;
             attract_original_intro = false;
+            attract_original_intro_start = 0;
         }
         else if (outrun.tick_frame && ++attract_sequence_counter > 240)
         {
@@ -372,12 +373,16 @@ void OOutputs::writeDigitalToConsole()
         attract_sequence_counter = 0;
         attract_sequence_view = 0;
         attract_original_intro = false;
+        attract_original_intro_start = 0;
     }
 
     // If the player manually leaves ORIGINAL while the automatic return intro
     // is running, cancel it immediately rather than flashing the wrong view.
     if (attract_original_intro && view != ORoad::VIEW_ORIGINAL)
+    {
         attract_original_intro = false;
+        attract_original_intro_start = 0;
+    }
 
     uint32_t attract_original_intro_elapsed = 0;
     if (attract_original_intro)

--- a/src/main/engine/ooutputs.cpp
+++ b/src/main/engine/ooutputs.cpp
@@ -33,14 +33,16 @@ namespace
     bool direct_view1_old = false;
     bool direct_view2_old = false;
     bool direct_view3_old = false;
+    bool viewpoint_old = false;
     int music_mode_synced = -1;
     bool music_color_initialized = false;
 
-    void handle_direct_view_buttons(bool controls_active)
+    void handle_direct_view_buttons(bool controls_active, bool attract_cycle_active)
     {
         const bool view1 = input.is_pressed(Input::VIEW1);
         const bool view2 = input.is_pressed(Input::VIEW2);
         const bool view3 = input.is_pressed(Input::VIEW3);
+        const bool viewpoint = input.is_pressed(Input::VIEWPOINT);
 
         if (controls_active)
         {
@@ -50,11 +52,20 @@ namespace
                 oroad.set_view_mode(ORoad::VIEW_ELEVATED);
             else if (view3 && !direct_view3_old)
                 oroad.set_view_mode(ORoad::VIEW_INCAR);
+            else if (attract_cycle_active && viewpoint && !viewpoint_old)
+            {
+                int mode = oroad.get_view_mode() + 1;
+                if (mode > ORoad::VIEW_INCAR)
+                    mode = ORoad::VIEW_ORIGINAL;
+
+                oroad.set_view_mode(mode);
+            }
         }
 
         direct_view1_old = view1;
         direct_view2_old = view2;
         direct_view3_old = view3;
+        viewpoint_old = viewpoint;
     }
 
     void sync_music_selection_mode(bool music_selection)
@@ -296,18 +307,29 @@ void OOutputs::writeDigitalToConsole()
     // Preserve the original SmartyPi console output path exactly as before.
     writeDigitalToConsole_base();
 
-    const bool view_controls_active =
+    const bool enhanced_attract_driving =
+        cannonball::state == cannonball::STATE_GAME &&
+        config.engine.new_attract &&
+        outrun.game_state == GS_ATTRACT;
+
+    const bool race_view_controls_active =
         outrun.game_state >= GS_START1 &&
         outrun.game_state <= GS_INGAME;
 
+    // Player view controls also work while the enhanced attract driving scene
+    // is active. This does not touch the attract timer or attract_view sequence,
+    // so the existing automatic view changes continue on their normal cadence.
+    handle_direct_view_buttons(
+        race_view_controls_active || enhanced_attract_driving,
+        enhanced_attract_driving);
+
     // During the race the single VIEW lamp remains the normal availability
-    // lamp. During music selection it becomes a mode-selection lamp and blinks
-    // in sync with the one matching VIEW1/2/3 lamp below.
+    // lamp. During music selection it becomes a mode-selection lamp. During
+    // enhanced attract driving it blinks together with the currently selected
+    // direct-view lamp instead of remaining steadily lit.
     const bool view_lamp_active =
         outrun.game_state >= GS_START1 &&
         outrun.game_state < GS_INIT_GAMEOVER;
-
-    handle_direct_view_buttons(view_controls_active);
 
     const uint8_t view = oroad.get_view_mode();
 
@@ -343,6 +365,13 @@ void OOutputs::writeDigitalToConsole()
         music_selection &&
         (outrun.tick_counter & BIT_4);
 
+    // Enhanced attract mode uses the same cabinet-friendly blink cadence. This
+    // is intentionally GS_ATTRACT-only, so Best OutRunners and the logo screen
+    // leave all view lamps off while the START lamp keeps its existing logic.
+    const bool attract_view_lamp_blink =
+        enhanced_attract_driving &&
+        (outrun.tick_counter & BIT_4);
+
     const int selected_game_mode = omusic.get_game_mode();
 
     const auto& settings = external_output_settings();
@@ -356,14 +385,22 @@ void OOutputs::writeDigitalToConsole()
         is_set(D_BRAKE_LAMP),
         music_selection
             ? (mode_lamp_blink ? 1 : 0)
-            : (view_lamp_active ? 1 : 0),
+            : (enhanced_attract_driving
+                ? (attract_view_lamp_blink ? 1 : 0)
+                : (view_lamp_active ? 1 : 0)),
         music_selection
             ? ((mode_lamp_blink && selected_game_mode == Outrun::MODE_ORIGINAL) ? 1 : 0)
-            : ((view_lamp_active && view == ORoad::VIEW_ORIGINAL) ? 1 : 0),
+            : (enhanced_attract_driving
+                ? ((attract_view_lamp_blink && view == ORoad::VIEW_ORIGINAL) ? 1 : 0)
+                : ((view_lamp_active && view == ORoad::VIEW_ORIGINAL) ? 1 : 0)),
         music_selection
             ? ((mode_lamp_blink && selected_game_mode == Outrun::MODE_CONT) ? 1 : 0)
-            : ((view_lamp_active && view == ORoad::VIEW_ELEVATED) ? 1 : 0),
+            : (enhanced_attract_driving
+                ? ((attract_view_lamp_blink && view == ORoad::VIEW_ELEVATED) ? 1 : 0)
+                : ((view_lamp_active && view == ORoad::VIEW_ELEVATED) ? 1 : 0)),
         music_selection
             ? ((mode_lamp_blink && selected_game_mode == Outrun::MODE_TTRIAL) ? 1 : 0)
-            : ((view_lamp_active && view == ORoad::VIEW_INCAR) ? 1 : 0));
+            : (enhanced_attract_driving
+                ? ((attract_view_lamp_blink && view == ORoad::VIEW_INCAR) ? 1 : 0)
+                : ((view_lamp_active && view == ORoad::VIEW_INCAR) ? 1 : 0)));
 }

--- a/src/main/engine/ooutputs.cpp
+++ b/src/main/engine/ooutputs.cpp
@@ -37,21 +37,31 @@ namespace
     int music_mode_synced = -1;
     bool music_color_initialized = false;
 
-    void handle_direct_view_buttons(bool controls_active, bool attract_cycle_active)
+    bool handle_direct_view_buttons(bool controls_active, bool attract_cycle_active)
     {
         const bool view1 = input.is_pressed(Input::VIEW1);
         const bool view2 = input.is_pressed(Input::VIEW2);
         const bool view3 = input.is_pressed(Input::VIEW3);
         const bool viewpoint = input.is_pressed(Input::VIEWPOINT);
+        bool view_changed = false;
 
         if (controls_active)
         {
             if (view1 && !direct_view1_old)
+            {
                 oroad.set_view_mode(ORoad::VIEW_ORIGINAL);
+                view_changed = true;
+            }
             else if (view2 && !direct_view2_old)
+            {
                 oroad.set_view_mode(ORoad::VIEW_ELEVATED);
+                view_changed = true;
+            }
             else if (view3 && !direct_view3_old)
+            {
                 oroad.set_view_mode(ORoad::VIEW_INCAR);
+                view_changed = true;
+            }
             else if (attract_cycle_active && viewpoint && !viewpoint_old)
             {
                 int mode = oroad.get_view_mode() + 1;
@@ -59,6 +69,7 @@ namespace
                     mode = ORoad::VIEW_ORIGINAL;
 
                 oroad.set_view_mode(mode);
+                view_changed = true;
             }
         }
 
@@ -66,6 +77,7 @@ namespace
         direct_view2_old = view2;
         direct_view3_old = view3;
         viewpoint_old = viewpoint;
+        return view_changed;
     }
 
     void sync_music_selection_mode(bool music_selection)
@@ -319,9 +331,11 @@ void OOutputs::writeDigitalToConsole()
     // Player view controls also work while the enhanced attract driving scene
     // is active. This does not touch the attract timer or attract_view sequence,
     // so the existing automatic view changes continue on their normal cadence.
-    handle_direct_view_buttons(
-        race_view_controls_active || enhanced_attract_driving,
-        enhanced_attract_driving);
+    const bool attract_manual_view_changed =
+        handle_direct_view_buttons(
+            race_view_controls_active || enhanced_attract_driving,
+            enhanced_attract_driving) &&
+        enhanced_attract_driving;
 
     // During the race the single VIEW lamp remains the normal availability
     // lamp. During music selection it becomes a mode-selection lamp. During
@@ -334,37 +348,61 @@ void OOutputs::writeDigitalToConsole()
     const uint8_t view = oroad.get_view_mode();
 
     // Mirror only the existing enhanced-attract automatic timer. This lets the
-    // lamp intro distinguish a genuine automatic return to ORIGINAL from any
-    // manual VIEW/VIEW1/VIEW2/VIEW3 change without modifying the view sequence.
+    // lamp logic distinguish an automatic view from a manual override without
+    // changing the actual automatic sequence in Outrun::tick_attract().
     static bool attract_sequence_tracking = false;
     static int attract_sequence_counter = 0;
     static uint8_t attract_sequence_view = 0;
+    static bool attract_current_view_automatic = true;
     static bool attract_original_intro = false;
-    static uint32_t attract_original_intro_start = 0;
+    static uint32_t attract_original_effect_start = 0;
 
     if (enhanced_attract_driving)
     {
+        bool automatic_view_changed = false;
+
         if (!attract_sequence_tracking)
         {
             attract_sequence_tracking = true;
             attract_sequence_counter = outrun.tick_frame ? 1 : 0;
             attract_sequence_view = 0;
+            attract_current_view_automatic = true;
             attract_original_intro = false;
-            attract_original_intro_start = 0;
+            attract_original_effect_start = outrun.tick_counter;
         }
         else if (outrun.tick_frame && ++attract_sequence_counter > 240)
         {
             attract_sequence_counter = 0;
             if (++attract_sequence_view > 2)
                 attract_sequence_view = 0;
+            automatic_view_changed = true;
+        }
 
-            // Only the automatic sequence can arm this intro. Manual changes
-            // never alter attract_sequence_view and therefore never trigger it.
+        if (automatic_view_changed)
+        {
+            attract_current_view_automatic = true;
+
             if (attract_sequence_view == 0)
             {
+                // Only an automatic return to ORIGINAL gets the three-flash
+                // intro and subsequent ping-pong chase.
                 attract_original_intro = true;
-                attract_original_intro_start = outrun.tick_counter;
+                attract_original_effect_start = outrun.tick_counter;
             }
+            else
+            {
+                attract_original_intro = false;
+                attract_original_effect_start = 0;
+            }
+        }
+
+        // Manual input happens after the engine's automatic attract update in
+        // the current frame, so a manual choice deliberately wins if both occur.
+        if (attract_manual_view_changed)
+        {
+            attract_current_view_automatic = false;
+            attract_original_intro = false;
+            attract_original_effect_start = 0;
         }
     }
     else
@@ -372,26 +410,20 @@ void OOutputs::writeDigitalToConsole()
         attract_sequence_tracking = false;
         attract_sequence_counter = 0;
         attract_sequence_view = 0;
+        attract_current_view_automatic = true;
         attract_original_intro = false;
-        attract_original_intro_start = 0;
-    }
-
-    // If the player manually leaves ORIGINAL while the automatic return intro
-    // is running, cancel it immediately rather than flashing the wrong view.
-    if (attract_original_intro && view != ORoad::VIEW_ORIGINAL)
-    {
-        attract_original_intro = false;
-        attract_original_intro_start = 0;
+        attract_original_effect_start = 0;
     }
 
     uint32_t attract_original_intro_elapsed = 0;
     if (attract_original_intro)
     {
         attract_original_intro_elapsed =
-            outrun.tick_counter - attract_original_intro_start;
+            outrun.tick_counter - attract_original_effect_start;
 
-        // Three complete blinks: 16 ticks on + 16 ticks off, repeated 3 times.
-        if (attract_original_intro_elapsed >= 96)
+        // All view-lamp effects run twice as fast as START: 8 ticks on,
+        // 8 ticks off. Three complete flashes therefore take 48 ticks.
+        if (attract_original_intro_elapsed >= 48)
             attract_original_intro = false;
     }
 
@@ -407,8 +439,7 @@ void OOutputs::writeDigitalToConsole()
     const bool press_start_available =
         config.engine.freeplay || ostats.credits > 0;
 
-    // Blink during attract PRESS START and throughout music selection. The
-    // attract phase uses the same BIT_4 timing as OHud::draw_insert_coin().
+    // START keeps its original BIT_4 blink cadence.
     const bool start_lamp_blink =
         ((press_start_screen && press_start_available) ||
          music_selection) &&
@@ -420,39 +451,49 @@ void OOutputs::writeDigitalToConsole()
         outrun.game_state >= GS_INIT_GAME &&
         outrun.game_state <= GS_BONUS;
 
-    // Music-select game mode indication. The traditional single VIEW lamp
-    // always blinks here, while only the lamp for the selected direct-view
-    // button blinks with it. The other two remain off.
+    // Music-select game mode indication remains unchanged.
     const bool mode_lamp_blink =
         music_selection &&
         (outrun.tick_counter & BIT_4);
 
-    // Custom attract views blink their matching button at the START-lamp rate.
-    const bool attract_custom_view_blink =
+    // Every Attract-mode view-button blink runs at BIT_3, twice the frequency
+    // of the START lamp's BIT_4 cadence.
+    const bool attract_view_blink_fast =
         enhanced_attract_driving &&
-        (outrun.tick_counter & BIT_4);
+        (outrun.tick_counter & BIT_3);
 
-    // An automatic return to ORIGINAL first flashes all three buttons three
-    // times. Afterwards the faster ping-pong chase restarts from VIEW1.
     const bool attract_original_intro_lit =
         attract_original_intro &&
-        (((attract_original_intro_elapsed >> 4) & 1) == 0);
+        (((attract_original_intro_elapsed >> 3) & 1) == 0);
 
-    uint8_t attract_chase_phase =
-        static_cast<uint8_t>((outrun.tick_counter >> 3) & 3);
-
-    if (view == ORoad::VIEW_ORIGINAL &&
-        !attract_original_intro &&
-        attract_original_intro_start != 0)
+    // Automatic ORIGINAL: after the three-flash intro, run the ping-pong chase
+    // VIEW1 -> VIEW2 -> VIEW3 -> VIEW2 -> ... at the same fast step rate.
+    uint8_t attract_chase_phase = 0;
+    if (attract_current_view_automatic &&
+        view == ORoad::VIEW_ORIGINAL &&
+        !attract_original_intro)
     {
-        const uint32_t chase_elapsed =
-            outrun.tick_counter - attract_original_intro_start - 96;
+        uint32_t chase_elapsed = 0;
+        if (attract_original_effect_start != 0)
+        {
+            chase_elapsed = outrun.tick_counter - attract_original_effect_start;
+            if (chase_elapsed >= 48)
+                chase_elapsed -= 48;
+            else if (attract_original_effect_start != outrun.tick_counter)
+                chase_elapsed = 0;
+        }
+        else
+        {
+            chase_elapsed = outrun.tick_counter;
+        }
+
         attract_chase_phase =
             static_cast<uint8_t>((chase_elapsed >> 3) & 3);
     }
 
     const bool attract_chase_active =
         enhanced_attract_driving &&
+        attract_current_view_automatic &&
         view == ORoad::VIEW_ORIGINAL &&
         !attract_original_intro;
 
@@ -467,6 +508,14 @@ void OOutputs::writeDigitalToConsole()
     const bool attract_chase_view3 =
         attract_chase_active &&
         attract_chase_phase == 2;
+
+    // Manual ORIGINAL is deliberately different from automatic ORIGINAL:
+    // only VIEW1 blinks, just like VIEW2/VIEW3 when selected manually.
+    const bool attract_manual_view1_blink =
+        enhanced_attract_driving &&
+        !attract_current_view_automatic &&
+        view == ORoad::VIEW_ORIGINAL &&
+        attract_view_blink_fast;
 
     const int selected_game_mode = omusic.get_game_mode();
 
@@ -488,7 +537,9 @@ void OOutputs::writeDigitalToConsole()
             ? ((mode_lamp_blink && selected_game_mode == Outrun::MODE_ORIGINAL) ? 1 : 0)
             : (enhanced_attract_driving
                 ? ((view == ORoad::VIEW_ORIGINAL)
-                    ? ((attract_original_intro_lit || attract_chase_view1) ? 1 : 0)
+                    ? ((attract_original_intro_lit ||
+                        attract_chase_view1 ||
+                        attract_manual_view1_blink) ? 1 : 0)
                     : 0)
                 : ((view_lamp_active && view == ORoad::VIEW_ORIGINAL) ? 1 : 0)),
         music_selection
@@ -496,13 +547,13 @@ void OOutputs::writeDigitalToConsole()
             : (enhanced_attract_driving
                 ? ((view == ORoad::VIEW_ORIGINAL)
                     ? ((attract_original_intro_lit || attract_chase_view2) ? 1 : 0)
-                    : ((view == ORoad::VIEW_ELEVATED && attract_custom_view_blink) ? 1 : 0))
+                    : ((view == ORoad::VIEW_ELEVATED && attract_view_blink_fast) ? 1 : 0))
                 : ((view_lamp_active && view == ORoad::VIEW_ELEVATED) ? 1 : 0)),
         music_selection
             ? ((mode_lamp_blink && selected_game_mode == Outrun::MODE_TTRIAL) ? 1 : 0)
             : (enhanced_attract_driving
                 ? ((view == ORoad::VIEW_ORIGINAL)
                     ? ((attract_original_intro_lit || attract_chase_view3) ? 1 : 0)
-                    : ((view == ORoad::VIEW_INCAR && attract_custom_view_blink) ? 1 : 0))
+                    : ((view == ORoad::VIEW_INCAR && attract_view_blink_fast) ? 1 : 0))
                 : ((view_lamp_active && view == ORoad::VIEW_INCAR) ? 1 : 0)));
 }


### PR DESCRIPTION
Adds cabinet-oriented view interaction and lamp effects to the enhanced attract driving sequence.

- keeps the existing automatic attract view rotation unchanged
- allows VIEW1/VIEW2/VIEW3 and VIEWPOINT to change views manually during enhanced attract driving
- START keeps its existing BIT_4 blink cadence
- all Attract-mode view-button blink effects run at BIT_3, twice the START blink frequency
- manual View 1: only VIEW1 blinks
- manual/automatic View 2: only VIEW2 blinks
- manual/automatic View 3: only VIEW3 blinks
- automatic Original view: VIEW1/2/3 run as a fast ping-pong chase (1 -> 2 -> 3 -> 2 -> ...)
- when the automatic attract sequence returns to Original, all three view buttons first flash together three times at the fast view-lamp rate, then the chase restarts from VIEW1
- manual switches to Original never trigger the three-flash intro or chase; they use the normal VIEW1 blink
- Best OutRunners and logo screens keep the view lamps off
- existing race and Music Select lamp behaviour remains unchanged