### PR TITLE
Add enhanced attract view showcase

### DIFF
--- a/src/main/engine/external_output_settings.hpp
+++ b/src/main/engine/external_output_settings.hpp
@@ -1,21 +1,46 @@
 #pragma once
 
+#include <array>
 #include <cstring>
+#include <memory>
 #include <string>
 
 #include "main.hpp"
 #include "roms.hpp"
 #include "video.hpp"
+#include "engine/oanimseq.hpp"
+#include "engine/oattractai.hpp"
+#include "engine/obonus.hpp"
+#include "engine/ocrash.hpp"
 #include "engine/oferrari.hpp"
 #include "engine/ohud.hpp"
 #include "engine/oinitengine.hpp"
 #include "engine/oinputs.hpp"
+#include "engine/olevelobjs.hpp"
+#include "engine/opalette.hpp"
 #include "engine/oroad.hpp"
+#include "engine/osmoke.hpp"
 #include "engine/osprites.hpp"
+#include "engine/ostats.hpp"
+#include "engine/otiles.hpp"
 #include "engine/otraffic.hpp"
 #include "frontend/config.hpp"
 #include "frontend/xml_parser.h"
 #include "sdl2/input.hpp"
+
+// windows.h defines PATH in some SDK configurations. TrackLoader also has the
+// legitimate LayOut::PATH constant, so hide only the Windows macro while this
+// header is parsed and restore it immediately afterwards.
+#ifdef PATH
+#pragma push_macro("PATH")
+#undef PATH
+#define CANNONBALL_RESTORE_PATH_MACRO
+#endif
+#include "trackloader.hpp"
+#ifdef CANNONBALL_RESTORE_PATH_MACRO
+#pragma pop_macro("PATH")
+#undef CANNONBALL_RESTORE_PATH_MACRO
+#endif
 
 // Optional external-output transport settings. SmartyPi remains independent.
 struct ExternalOutputSettings
@@ -64,6 +89,11 @@ inline ExternalOutputSettings& external_output_settings()
 class ExternalOutputsWithAttractShowcase : public ExternalOutputs
 {
 public:
+    bool is_showcase_active() const
+    {
+        return showcase_active;
+    }
+
     void update(bool enable_network,
                 bool enable_windows,
                 int port,
@@ -129,8 +159,38 @@ public:
     }
 
 private:
-    static constexpr uint32_t VIEW_TIME = 120; // 4 seconds at the 30 Hz game tick.
+    static constexpr uint32_t VIEW_TIME = 210; // 7 seconds at the 30 Hz game tick.
     static constexpr uint32_t TOTAL_TIME = VIEW_TIME * 3;
+
+    struct AttractResumeSnapshot
+    {
+        ORoad road;
+        OInitEngine initengine;
+        OFerrari ferrari;
+        OSprites sprites;
+        OTraffic traffic;
+        OLevelObjs levelobjs;
+        OAttractAI attractai;
+        OCrash crash;
+        OAnimSeq animseq;
+        OSmoke smoke;
+        OBonus bonus;
+        OStats stats;
+        OPalette palette;
+        OTiles tiles;
+
+        hwtiles hw_tiles;
+        hwsprites hw_sprites;
+        HWRoad hw_road;
+
+        TrackLoader::RuntimeState track;
+        Outrun::AttractRuntimeState attract;
+        std::array<uint16_t, S16_PALETTE_ENTRIES> palette_ram;
+
+        int16_t steering_adjust;
+        uint8_t acc_adjust;
+        uint8_t brake_adjust;
+    };
 
     bool showcase_pending = false;
     bool showcase_active = false;
@@ -144,6 +204,86 @@ private:
     uint8_t phase_view = ORoad::VIEW_ORIGINAL;
     uint32_t showcase_start_tick = 0;
     uint32_t phase_start_tick = 0;
+    std::unique_ptr<AttractResumeSnapshot> resume_state;
+
+    void capture_attract_state()
+    {
+        resume_state.reset(new AttractResumeSnapshot());
+
+        resume_state->road = oroad;
+        resume_state->initengine = oinitengine;
+        resume_state->ferrari = oferrari;
+        resume_state->sprites = osprites;
+        resume_state->traffic = otraffic;
+        resume_state->levelobjs = olevelobjs;
+        resume_state->attractai = oattractai;
+        resume_state->crash = ocrash;
+        resume_state->animseq = oanimseq;
+        resume_state->smoke = osmoke;
+        resume_state->bonus = obonus;
+        resume_state->stats = ostats;
+        resume_state->palette = opalette;
+        resume_state->tiles = otiles;
+
+        resume_state->hw_tiles = *video.tile_layer;
+        resume_state->hw_sprites = *video.sprite_layer;
+        resume_state->hw_road = hwroad;
+
+        resume_state->track = trackloader.capture_runtime_state();
+        resume_state->attract = outrun.capture_attract_runtime_state();
+
+        for (uint32_t i = 0; i < S16_PALETTE_ENTRIES; i++)
+            resume_state->palette_ram[i] =
+                video.read_pal16(S16_PALETTE_BASE + (i << 1));
+
+        resume_state->steering_adjust = oinputs.steering_adjust;
+        resume_state->acc_adjust = oinputs.acc_adjust;
+        resume_state->brake_adjust = oinputs.brake_adjust;
+    }
+
+    void restore_attract_state()
+    {
+        if (!resume_state)
+            return;
+
+        // Restore the software-side engine first. Ferrari/traffic/crash objects
+        // contain pointers into the global OSprites table, whose address never
+        // changes; restoring OSprites puts the pointed-to entries back in place.
+        osprites = resume_state->sprites;
+        oroad = resume_state->road;
+        oinitengine = resume_state->initengine;
+        oferrari = resume_state->ferrari;
+        otraffic = resume_state->traffic;
+        olevelobjs = resume_state->levelobjs;
+        oattractai = resume_state->attractai;
+        ocrash = resume_state->crash;
+        oanimseq = resume_state->animseq;
+        osmoke = resume_state->smoke;
+        obonus = resume_state->bonus;
+        ostats = resume_state->stats;
+        opalette = resume_state->palette;
+        otiles = resume_state->tiles;
+
+        trackloader.restore_runtime_state(resume_state->track);
+        outrun.restore_attract_runtime_state(resume_state->attract);
+
+        // Restore the emulated video hardware too. This is what makes resuming
+        // work even if the normal attract had already reached a later stage,
+        // palette transition or road split before High Scores / Logo appeared.
+        *video.tile_layer = resume_state->hw_tiles;
+        *video.sprite_layer = resume_state->hw_sprites;
+        hwroad = resume_state->hw_road;
+
+        uint32_t pal_addr = S16_PALETTE_BASE;
+        for (uint32_t i = 0; i < S16_PALETTE_ENTRIES; i++)
+            video.write_pal16(&pal_addr, resume_state->palette_ram[i]);
+
+        oinputs.steering_adjust = resume_state->steering_adjust;
+        oinputs.acc_adjust = resume_state->acc_adjust;
+        oinputs.brake_adjust = resume_state->brake_adjust;
+
+        resume_state.reset();
+    }
 
     void clear_double_row(uint8_t y)
     {
@@ -248,9 +388,9 @@ private:
 
     void reset_showcase_segment(uint8_t view)
     {
-        // Reuse the first few seconds of Coconut Beach for every camera. This
-        // keeps all three comparisons on the same straight road section and
-        // avoids ever reaching the first bend during the 12-second showcase.
+        // Reuse the opening Coconut Beach straight for every camera. Each
+        // seven-second section starts from the same point, so all views get a
+        // directly comparable road scene without reaching the first bend.
         oroad.init();
         oinitengine.init(0);
 
@@ -290,22 +430,42 @@ private:
         showcase_active = true;
         showcase_phase = 0;
         showcase_start_tick = outrun.tick_counter;
+
+        // GS_INIT has just restored the normal Enhanced Attract to the point at
+        // which it stopped before High Scores / Logo. Freeze that exact runtime
+        // state here, use the live engine for the disposable showcase, then put
+        // this snapshot back afterwards.
+        capture_attract_state();
+
         video.clear_text_ram();
         reset_showcase_segment(ORoad::VIEW_ORIGINAL);
     }
 
     void end_showcase()
     {
+        restore_attract_state();
+
         showcase_active = false;
         showcase_phase = -1;
         manual_override = false;
-        video.clear_text_ram();
-        oroad.set_view_mode(ORoad::VIEW_ORIGINAL, true);
-        otraffic.set_max_traffic();
 
-        // GS_INIT restarts the existing enhanced attract timer/view sequence on
-        // the next engine tick. No normal attract behaviour is replaced.
-        outrun.game_state = GS_INIT;
+        // Continue the already-resumed Enhanced Attract directly. Do not enter
+        // GS_INIT again: doing so would reset its timer/view sequence instead of
+        // carrying on from the state captured immediately after the logo.
+        outrun.game_state = GS_ATTRACT;
+    }
+
+    void abort_showcase(bool restore_attract)
+    {
+        if (restore_attract)
+            restore_attract_state();
+        else
+            resume_state.reset();
+
+        showcase_active = false;
+        showcase_pending = false;
+        showcase_phase = -1;
+        manual_override = false;
     }
 
     void update_showcase()
@@ -334,11 +494,12 @@ private:
         {
             if (!enhanced_game || outrun.game_state != GS_ATTRACT)
             {
-                showcase_active = false;
-                showcase_pending = false;
-                showcase_phase = -1;
-                manual_override = false;
-                otraffic.set_max_traffic();
+                // If the player inserted a credit, the game has legitimately
+                // left Attract for Music Select; do not overwrite that state.
+                // If Enhanced Attract itself was merely disabled while we are
+                // still in GS_ATTRACT, put the pre-showcase scene back first.
+                const bool can_restore = outrun.game_state == GS_ATTRACT;
+                abort_showcase(can_restore);
             }
             else
             {
@@ -371,7 +532,7 @@ private:
                         // The existing Enhanced Attract view timer still ticks
                         // underneath us. Hold the showcase's intended automatic
                         // view against that timer, but never fight a real player
-                        // VR-button override inside the current 4-second phase.
+                        // VR-button override inside the current seven-second phase.
                         if (!manual_override && oroad.get_view_mode() != phase_view)
                             oroad.set_view_mode(phase_view, true);
                     }

--- a/src/main/engine/external_output_settings.hpp
+++ b/src/main/engine/external_output_settings.hpp
@@ -16,6 +16,7 @@
 #include "engine/otraffic.hpp"
 #include "frontend/config.hpp"
 #include "frontend/xml_parser.h"
+#include "sdl2/input.hpp"
 
 // Optional external-output transport settings. SmartyPi remains independent.
 struct ExternalOutputSettings
@@ -129,12 +130,16 @@ public:
     }
 
 private:
-    static const uint32_t VIEW_TIME = 120; // 4 seconds at the 30 Hz game tick.
-    static const uint32_t TOTAL_TIME = VIEW_TIME * 3;
+    static constexpr uint32_t VIEW_TIME = 120; // 4 seconds at the 30 Hz game tick.
+    static constexpr uint32_t TOTAL_TIME = VIEW_TIME * 3;
 
     bool showcase_pending = false;
     bool showcase_active = false;
     bool manual_override = false;
+    bool view1_old = false;
+    bool view2_old = false;
+    bool view3_old = false;
+    bool viewpoint_old = false;
     int previous_game_state = -1;
     int showcase_phase = -1;
     uint8_t phase_view = ORoad::VIEW_ORIGINAL;
@@ -197,7 +202,7 @@ private:
         if (view == ORoad::VIEW_ELEVATED)
             view_name = "ELEVATED VIEW";
         else if (view == ORoad::VIEW_INCAR)
-            view_name = "IN-CAR VIEW";
+            view_name = "IN CAR VIEW";
 
         // Same yellow/black double-row style as the enhanced Music Select song
         // title. The selected view deliberately blinks like an arcade prompt.
@@ -205,6 +210,26 @@ private:
             draw_double_row_centered(7, view_name, 0x8AA0);
         else
             clear_double_row(7);
+    }
+
+    bool manual_view_pressed()
+    {
+        const bool view1 = input.is_pressed(Input::VIEW1);
+        const bool view2 = input.is_pressed(Input::VIEW2);
+        const bool view3 = input.is_pressed(Input::VIEW3);
+        const bool viewpoint = input.is_pressed(Input::VIEWPOINT);
+
+        const bool pressed =
+            (view1 && !view1_old) ||
+            (view2 && !view2_old) ||
+            (view3 && !view3_old) ||
+            (viewpoint && !viewpoint_old);
+
+        view1_old = view1;
+        view2_old = view2;
+        view3_old = view3;
+        viewpoint_old = viewpoint;
+        return pressed;
     }
 
     void hide_non_palm_opening_scenery()
@@ -339,22 +364,29 @@ private:
                         showcase_phase = phase;
                         reset_showcase_segment(VIEWS[phase]);
                     }
-                    else if (oroad.get_view_mode() != phase_view)
+                    else
                     {
-                        // OOutputs already processed the cabinet/player VR
-                        // button before this wrapper runs, so a mismatch here is
-                        // a real manual override. Keep it until the next phase.
-                        manual_override = true;
+                        if (manual_view_pressed())
+                            manual_override = true;
+
+                        // The existing Enhanced Attract view timer still ticks
+                        // underneath us. Hold the showcase's intended automatic
+                        // view against that timer, but never fight a real player
+                        // VR-button override inside the current 4-second phase.
+                        if (!manual_override && oroad.get_view_mode() != phase_view)
+                            oroad.set_view_mode(phase_view, true);
                     }
 
-                    // Keep the demonstration pinned to full speed and centreline
-                    // regardless of normal AI braking/collision decisions.
+                    // Keep the demonstration pinned to full speed, normal road
+                    // width and centreline regardless of AI/collision decisions.
                     oinitengine.car_increment = 0xFA << 16;
                     oferrari.car_inc_old = 0xFA;
                     oinitengine.car_x_pos = 0;
                     oinputs.acc_adjust = 0xFF;
                     oinputs.brake_adjust = 0;
                     oinputs.steering_adjust = 0;
+                    oroad.road_width = 0xD4 << 16;
+                    oroad.road_width_bak = 0xD4;
                     otraffic.disable_traffic();
                     otraffic.set_custom_max_traffic(0);
                     otraffic.ai_traffic = 0;
@@ -362,6 +394,12 @@ private:
                     draw_showcase_text();
                 }
             }
+        }
+        else
+        {
+            // Keep edge trackers current outside the showcase so holding a VR
+            // button across the transition cannot look like a fresh press.
+            manual_view_pressed();
         }
 
         previous_game_state = outrun.game_state;

--- a/src/main/engine/external_output_settings.hpp
+++ b/src/main/engine/external_output_settings.hpp
@@ -5,7 +5,6 @@
 
 #include "main.hpp"
 #include "roms.hpp"
-#include "trackloader.hpp"
 #include "video.hpp"
 #include "engine/oferrari.hpp"
 #include "engine/ohud.hpp"

--- a/src/main/engine/external_output_settings.hpp
+++ b/src/main/engine/external_output_settings.hpp
@@ -1,7 +1,19 @@
 #pragma once
 
+#include <cstring>
 #include <string>
 
+#include "main.hpp"
+#include "roms.hpp"
+#include "trackloader.hpp"
+#include "video.hpp"
+#include "engine/oferrari.hpp"
+#include "engine/ohud.hpp"
+#include "engine/oinitengine.hpp"
+#include "engine/oinputs.hpp"
+#include "engine/oroad.hpp"
+#include "engine/osprites.hpp"
+#include "engine/otraffic.hpp"
 #include "frontend/config.hpp"
 #include "frontend/xml_parser.h"
 
@@ -45,3 +57,317 @@ inline ExternalOutputSettings& external_output_settings()
     settings.load_once();
     return settings;
 }
+
+// Enhanced-attract showcase wrapper. external_outputs.hpp is included before
+// this header, so deriving here lets the existing OOutputs call site remain
+// untouched while the showcase can override the final lamp values.
+class ExternalOutputsWithAttractShowcase : public ExternalOutputs
+{
+public:
+    void update(bool enable_network,
+                bool enable_windows,
+                int port,
+                bool application_running,
+                int start_lamp,
+                int brake_lamp,
+                int view_lamp,
+                int view1_lamp,
+                int view2_lamp,
+                int view3_lamp)
+    {
+        update_showcase();
+
+        if (showcase_active)
+        {
+            // The dedicated VR lamps own the presentation during the showcase.
+            view_lamp = 0;
+            view1_lamp = 0;
+            view2_lamp = 0;
+            view3_lamp = 0;
+
+            const bool fast_blink = (outrun.tick_counter & BIT_3) != 0;
+            const uint8_t view = oroad.get_view_mode();
+
+            if (view == ORoad::VIEW_ORIGINAL)
+            {
+                if (manual_override)
+                {
+                    view1_lamp = fast_blink ? 1 : 0;
+                }
+                else
+                {
+                    // Automatic ORIGINAL uses the same fast ping-pong chase as
+                    // the enhanced attract mode: 1 -> 2 -> 3 -> 2 -> ...
+                    const uint8_t chase =
+                        static_cast<uint8_t>(((outrun.tick_counter - phase_start_tick) >> 3) & 3);
+                    view1_lamp = chase == 0 ? 1 : 0;
+                    view2_lamp = (chase == 1 || chase == 3) ? 1 : 0;
+                    view3_lamp = chase == 2 ? 1 : 0;
+                }
+            }
+            else if (view == ORoad::VIEW_ELEVATED)
+            {
+                view2_lamp = fast_blink ? 1 : 0;
+            }
+            else if (view == ORoad::VIEW_INCAR)
+            {
+                view3_lamp = fast_blink ? 1 : 0;
+            }
+        }
+
+        ExternalOutputs::update(
+            enable_network,
+            enable_windows,
+            port,
+            application_running,
+            start_lamp,
+            brake_lamp,
+            view_lamp,
+            view1_lamp,
+            view2_lamp,
+            view3_lamp);
+    }
+
+private:
+    static const uint32_t VIEW_TIME = 120; // 4 seconds at the 30 Hz game tick.
+    static const uint32_t TOTAL_TIME = VIEW_TIME * 3;
+
+    bool showcase_pending = false;
+    bool showcase_active = false;
+    bool manual_override = false;
+    int previous_game_state = -1;
+    int showcase_phase = -1;
+    uint8_t phase_view = ORoad::VIEW_ORIGINAL;
+    uint32_t showcase_start_tick = 0;
+    uint32_t phase_start_tick = 0;
+
+    void clear_double_row(uint8_t y)
+    {
+        for (int x = 0; x < 40; x++)
+        {
+            video.write_text16(ohud.translate(x, y), 0);
+            video.write_text16(ohud.translate(x, y) + 0x80, 0);
+        }
+    }
+
+    void draw_double_row_centered(uint8_t y, const char* text, uint16_t pal)
+    {
+        int length = static_cast<int>(std::strlen(text));
+        if (length > 40)
+            length = 40;
+
+        const int x_start = 20 - (length / 2);
+        clear_double_row(y);
+
+        uint32_t dst_addr = ohud.translate(x_start, y);
+
+        for (int i = 0; i < length; i++)
+        {
+            uint16_t c = static_cast<uint8_t>(text[i]);
+
+            if (c >= 'a' && c <= 'z')
+                c -= 0x20;
+
+            if (c == ' ')
+            {
+                video.write_text16(&dst_addr, 0);
+                video.write_text16(0x7E + dst_addr, 0);
+            }
+            else if (c >= 'A' && c <= 'Z')
+            {
+                c = ((c - 'A') * 2) + pal;
+                video.write_text16(&dst_addr, c);
+                video.write_text16(0x7E + dst_addr, c + 1);
+            }
+        }
+    }
+
+    void draw_showcase_text()
+    {
+        // Extract the exact palette used by the original SELECT MUSIC prompt.
+        uint32_t select_music_style = TEXT2_SELECT_MUSIC + 2;
+        uint16_t prompt_pal = roms.rom0.read8(&select_music_style);
+        prompt_pal = 0x80A0 | ((prompt_pal << 9) | ((prompt_pal >> 7) & 1));
+
+        draw_double_row_centered(2, "TRY THREE DIFFERENT VIEWS", prompt_pal);
+        draw_double_row_centered(4, "WITH THE VR BUTTONS!", prompt_pal);
+
+        const char* view_name = "ORIGINAL VIEW";
+        const uint8_t view = oroad.get_view_mode();
+        if (view == ORoad::VIEW_ELEVATED)
+            view_name = "ELEVATED VIEW";
+        else if (view == ORoad::VIEW_INCAR)
+            view_name = "IN-CAR VIEW";
+
+        // Same yellow/black double-row style as the enhanced Music Select song
+        // title. The selected view deliberately blinks like an arcade prompt.
+        if (outrun.tick_counter & BIT_4)
+            draw_double_row_centered(7, view_name, 0x8AA0);
+        else
+            clear_double_row(7);
+    }
+
+    void hide_non_palm_opening_scenery()
+    {
+        // Stage 1's palm trees use the normal level-object routine. Hide the
+        // special start-line/water/grass/cloud routines so the short showcase
+        // reads as road + palms rather than a normal attract-stage scene.
+        // Limit this to the stage-1 level-object slots; Ferrari/passenger/smoke
+        // slots live outside this range and remain untouched.
+        for (int i = 0; i <= 0x44; i++)
+        {
+            oentry* sprite = &osprites.jump_table[i];
+            if ((sprite->control & OSprites::ENABLE) && sprite->function_holder != 0)
+                sprite->control &= ~OSprites::ENABLE;
+        }
+    }
+
+    void reset_showcase_segment(uint8_t view)
+    {
+        // Reuse the first few seconds of Coconut Beach for every camera. This
+        // keeps all three comparisons on the same straight road section and
+        // avoids ever reaching the first bend during the 12-second showcase.
+        oroad.init();
+        oinitengine.init(0);
+
+        oferrari.car_ctrl_active = true;
+        oinitengine.car_x_pos = 0;
+        oinitengine.car_x_old = 0;
+        oroad.car_x_bak = 0;
+
+        // Start at full normal OutRun speed instead of accelerating from rest.
+        oinitengine.car_increment = 0xFA << 16;
+        oferrari.car_inc_old = 0xFA;
+        oinputs.acc_adjust = 0xFF;
+        oinputs.brake_adjust = 0;
+        oinputs.steering_adjust = 0;
+
+        // Present a normal single road immediately, without the wide start-grid
+        // road geometry, and suppress every traffic slot/spawn during the demo.
+        oroad.road_width = 0xD4 << 16;
+        oroad.road_width_bak = 0xD4;
+        otraffic.disable_traffic();
+        otraffic.set_custom_max_traffic(0);
+        otraffic.ai_traffic = 0;
+
+        // Remove any hard-coded start-line objects left in the reusable slots.
+        for (int i = 0; i <= 0x44; i++)
+            osprites.jump_table[i].control &= ~OSprites::ENABLE;
+
+        oroad.set_view_mode(view, true);
+        phase_view = view;
+        manual_override = false;
+        phase_start_tick = outrun.tick_counter;
+    }
+
+    void start_showcase()
+    {
+        showcase_pending = false;
+        showcase_active = true;
+        showcase_phase = 0;
+        showcase_start_tick = outrun.tick_counter;
+        video.clear_text_ram();
+        reset_showcase_segment(ORoad::VIEW_ORIGINAL);
+    }
+
+    void end_showcase()
+    {
+        showcase_active = false;
+        showcase_phase = -1;
+        manual_override = false;
+        video.clear_text_ram();
+        oroad.set_view_mode(ORoad::VIEW_ORIGINAL, true);
+        otraffic.set_max_traffic();
+
+        // GS_INIT restarts the existing enhanced attract timer/view sequence on
+        // the next engine tick. No normal attract behaviour is replaced.
+        outrun.game_state = GS_INIT;
+    }
+
+    void update_showcase()
+    {
+        const bool enhanced_game =
+            cannonball::state == cannonball::STATE_GAME &&
+            config.engine.new_attract;
+
+        // Logo timeout changes GS_LOGO -> GS_INIT for one frame. Remember that
+        // edge, then start only when GS_INIT has entered GS_ATTRACT next tick.
+        if (enhanced_game &&
+            previous_game_state == GS_LOGO &&
+            outrun.game_state == GS_INIT)
+        {
+            showcase_pending = true;
+        }
+
+        if (showcase_pending &&
+            enhanced_game &&
+            outrun.game_state == GS_ATTRACT)
+        {
+            start_showcase();
+        }
+
+        if (showcase_active)
+        {
+            if (!enhanced_game || outrun.game_state != GS_ATTRACT)
+            {
+                showcase_active = false;
+                showcase_pending = false;
+                showcase_phase = -1;
+                manual_override = false;
+                otraffic.set_max_traffic();
+            }
+            else
+            {
+                const uint32_t elapsed = outrun.tick_counter - showcase_start_tick;
+
+                if (elapsed >= TOTAL_TIME)
+                {
+                    end_showcase();
+                }
+                else
+                {
+                    const int phase = static_cast<int>(elapsed / VIEW_TIME);
+                    static const uint8_t VIEWS[] =
+                    {
+                        ORoad::VIEW_ORIGINAL,
+                        ORoad::VIEW_ELEVATED,
+                        ORoad::VIEW_INCAR,
+                    };
+
+                    if (phase != showcase_phase)
+                    {
+                        showcase_phase = phase;
+                        reset_showcase_segment(VIEWS[phase]);
+                    }
+                    else if (oroad.get_view_mode() != phase_view)
+                    {
+                        // OOutputs already processed the cabinet/player VR
+                        // button before this wrapper runs, so a mismatch here is
+                        // a real manual override. Keep it until the next phase.
+                        manual_override = true;
+                    }
+
+                    // Keep the demonstration pinned to full speed and centreline
+                    // regardless of normal AI braking/collision decisions.
+                    oinitengine.car_increment = 0xFA << 16;
+                    oferrari.car_inc_old = 0xFA;
+                    oinitengine.car_x_pos = 0;
+                    oinputs.acc_adjust = 0xFF;
+                    oinputs.brake_adjust = 0;
+                    oinputs.steering_adjust = 0;
+                    otraffic.disable_traffic();
+                    otraffic.set_custom_max_traffic(0);
+                    otraffic.ai_traffic = 0;
+                    hide_non_palm_opening_scenery();
+                    draw_showcase_text();
+                }
+            }
+        }
+
+        previous_game_state = outrun.game_state;
+    }
+};
+
+// ooutputs.cpp declares its transport object after this header is included.
+// Use the showcase-aware subclass without touching the existing output wrapper.
+#define ExternalOutputs ExternalOutputsWithAttractShowcase

--- a/src/main/engine/outrun.hpp
+++ b/src/main/engine/outrun.hpp
@@ -180,6 +180,13 @@ class OOutputs;
 class Outrun
 {
 public:
+    struct AttractRuntimeState
+    {
+        uint8_t view;
+        int16_t counter;
+        uint32_t car_increment_backup;
+    };
+
     OOutputs* outputs;
 
     bool freeze_timer;
@@ -220,6 +227,22 @@ public:
 	void vint();
     void init_best_outrunners();
     void select_course(const bool jap, const bool prototype);
+
+    AttractRuntimeState capture_attract_runtime_state() const
+    {
+        AttractRuntimeState state;
+        state.view = attract_view;
+        state.counter = attract_counter;
+        state.car_increment_backup = car_inc_bak;
+        return state;
+    }
+
+    void restore_attract_runtime_state(const AttractRuntimeState& state)
+    {
+        attract_view = state.view;
+        attract_counter = state.counter;
+        car_inc_bak = state.car_increment_backup;
+    }
 
     // JJP - expose skidding state
     bool SkiddingOnRoad();

--- a/src/main/trackloader.cpp
+++ b/src/main/trackloader.cpp
@@ -203,7 +203,7 @@ void TrackLoader::init_layout_tracks(bool jap)
         setup_level(&levels[i], layout, STAGE_ADR);
 
         // CPU 1 Data
-        const uint32_t PATH_ADR = layout->read32(LayOut::PATH);
+        const uint32_t PATH_ADR = layout->read32(LayOut::PATH_OFFSET);
         levels[i].path = &layout->rom[ PATH_ADR + ((ROAD_END_CPU1 * sizeof(uint32_t)) * i) ];
     }
 

--- a/src/main/trackloader.hpp
+++ b/src/main/trackloader.hpp
@@ -16,6 +16,46 @@
 
 #include "globals.hpp"
 
+// Some Windows SDK / platform headers define short, generic macros such as
+// END_PATH. LayOut historically uses similarly named constants for offsets in
+// its binary header. Preprocessor macros are expanded even after `LayOut::`, so
+// clear every potentially colliding field name before declaring the struct.
+// Keeping this protection here makes TrackLoader safe regardless of include
+// order (notably when included by the Windows external-output path).
+#ifdef HEADER
+#undef HEADER
+#endif
+#ifdef PATH_OFFSET
+#undef PATH_OFFSET
+#endif
+#ifdef LEVELS
+#undef LEVELS
+#endif
+#ifdef END_PATH
+#undef END_PATH
+#endif
+#ifdef END_LEVELS
+#undef END_LEVELS
+#endif
+#ifdef SPLIT_PATH
+#undef SPLIT_PATH
+#endif
+#ifdef SPLIT_LEVEL
+#undef SPLIT_LEVEL
+#endif
+#ifdef PAL_SKY
+#undef PAL_SKY
+#endif
+#ifdef PAL_GND
+#undef PAL_GND
+#endif
+#ifdef SPRITE_MAPS
+#undef SPRITE_MAPS
+#endif
+#ifdef HEIGHT_MAPS
+#undef HEIGHT_MAPS
+#endif
+
 // Road Generator Palette Representation
 struct RoadPalette
 {

--- a/src/main/trackloader.hpp
+++ b/src/main/trackloader.hpp
@@ -16,6 +16,14 @@
 
 #include "globals.hpp"
 
+// Some Windows SDK/include combinations define PATH as a macro. LayOut has
+// used PATH as a binary-header field name for years, so remove the macro at
+// the header boundary before the struct is parsed. This makes inclusion safe
+// regardless of include order.
+#ifdef PATH
+#undef PATH
+#endif
+
 // Road Generator Palette Representation
 struct RoadPalette
 {

--- a/src/main/trackloader.hpp
+++ b/src/main/trackloader.hpp
@@ -64,6 +64,15 @@ class TrackLoader
 {
 
 public:
+    struct RuntimeState
+    {
+        Level* current_level;
+        uint8_t* current_path;
+        uint32_t curve_offset;
+        uint32_t wh_offset;
+        uint32_t scenery_offset;
+    };
+
     // Reference to stage mapping/ordering table
     uint8_t* stage_data;
 
@@ -92,6 +101,26 @@ public:
 
     TrackLoader();
     ~TrackLoader();
+
+    RuntimeState capture_runtime_state() const
+    {
+        RuntimeState state;
+        state.current_level = current_level;
+        state.current_path = current_path;
+        state.curve_offset = curve_offset;
+        state.wh_offset = wh_offset;
+        state.scenery_offset = scenery_offset;
+        return state;
+    }
+
+    void restore_runtime_state(const RuntimeState& state)
+    {
+        current_level = state.current_level;
+        current_path = state.current_path;
+        curve_offset = state.curve_offset;
+        wh_offset = state.wh_offset;
+        scenery_offset = state.scenery_offset;
+    }
 
     void init(bool jap);
     bool set_layout_track(const char* filename);

--- a/src/main/trackloader.hpp
+++ b/src/main/trackloader.hpp
@@ -16,14 +16,6 @@
 
 #include "globals.hpp"
 
-// Some Windows SDK/include combinations define PATH as a macro. LayOut has
-// used PATH as a binary-header field name for years, so remove the macro at
-// the header boundary before the struct is parsed. This makes inclusion safe
-// regardless of include order.
-#ifdef PATH
-#undef PATH
-#endif
-
 // Road Generator Palette Representation
 struct RoadPalette
 {
@@ -54,8 +46,8 @@ struct LayOut
     static const uint32_t EXPECTED_VERSION = 1;
 
     static const uint32_t HEADER      = 0;
-    static const uint32_t PATH        = HEADER      + sizeof(uint32_t) + sizeof(uint8_t);
-    static const uint32_t LEVELS      = PATH        + sizeof(uint32_t);
+    static const uint32_t PATH_OFFSET = HEADER      + sizeof(uint32_t) + sizeof(uint8_t);
+    static const uint32_t LEVELS      = PATH_OFFSET + sizeof(uint32_t);
     static const uint32_t END_PATH    = LEVELS      + (STAGES * sizeof(uint32_t));
     static const uint32_t END_LEVELS  = END_PATH    + sizeof(uint32_t);
     static const uint32_t SPLIT_PATH  = END_LEVELS  + (5 * sizeof(uint32_t));


### PR DESCRIPTION
Adds a short view showcase after the logo in Enhanced Attract mode.

- triggers only after the Logo -> Attract transition
- demonstrates Original, Elevated and In-Car views for 7 seconds each
- reuses the opening Coconut Beach section for each view and forces full speed/centreline driving
- suppresses traffic and non-standard opening scenery during the showcase
- shows `TRY THREE DIFFERENT VIEWS / WITH THE VR BUTTONS!` in the Music Select prompt style
- blinks the current view name in the Music Select song-title style
- keeps manual VR/view buttons usable during the showcase
- drives the dedicated view lamps in sync with the displayed view
- snapshots the running Enhanced Attract state before the showcase and restores road, stage/split loader, sprites, palette and internal view timing afterwards
- resumes the normal Enhanced Attract exactly where it had stopped before High Scores / Logo instead of restarting Coconut Beach

Draft for compile/runtime testing before merge.