### PR TITLE
Try live enhanced-attract view showcase

### DIFF
--- a/src/main/engine/external_output_settings.hpp
+++ b/src/main/engine/external_output_settings.hpp
@@ -95,19 +95,10 @@ public:
 
             if (view == ORoad::VIEW_ORIGINAL)
             {
-                if (manual_override)
-                {
-                    view1_lamp = fast_blink ? 1 : 0;
-                }
-                else
-                {
-                    // Automatic ORIGINAL uses the existing ping-pong lamp chase.
-                    const uint8_t chase =
-                        static_cast<uint8_t>(((cannonball::frame - phase_start_frame) >> 3) & 3);
-                    view1_lamp = chase == 0 ? 1 : 0;
-                    view2_lamp = (chase == 1 || chase == 3) ? 1 : 0;
-                    view3_lamp = chase == 2 ? 1 : 0;
-                }
+                // During the showcase View 1 is represented only by its own
+                // lamp. The normal ping-pong chase remains an attract-mode
+                // effect outside this presentation.
+                view1_lamp = fast_blink ? 1 : 0;
             }
             else if (view == ORoad::VIEW_ELEVATED)
             {
@@ -219,7 +210,7 @@ private:
         if (phase_view == ORoad::VIEW_ELEVATED)
             return "ELEVATED VIEW";
         if (phase_view == ORoad::VIEW_INCAR)
-            return "IN CAR VIEW";
+            return "BUMPER VIEW";
         return "ORIGINAL VIEW";
     }
 

--- a/src/main/engine/external_output_settings.hpp
+++ b/src/main/engine/external_output_settings.hpp
@@ -1,21 +1,46 @@
 #pragma once
 
+#include <array>
 #include <cstring>
+#include <memory>
 #include <string>
 
 #include "main.hpp"
 #include "roms.hpp"
 #include "video.hpp"
+#include "engine/oanimseq.hpp"
+#include "engine/oattractai.hpp"
+#include "engine/obonus.hpp"
+#include "engine/ocrash.hpp"
 #include "engine/oferrari.hpp"
 #include "engine/ohud.hpp"
 #include "engine/oinitengine.hpp"
 #include "engine/oinputs.hpp"
+#include "engine/olevelobjs.hpp"
+#include "engine/opalette.hpp"
 #include "engine/oroad.hpp"
+#include "engine/osmoke.hpp"
 #include "engine/osprites.hpp"
+#include "engine/ostats.hpp"
+#include "engine/otiles.hpp"
 #include "engine/otraffic.hpp"
 #include "frontend/config.hpp"
 #include "frontend/xml_parser.h"
 #include "sdl2/input.hpp"
+
+// windows.h defines PATH in some SDK configurations. TrackLoader also has the
+// legitimate LayOut::PATH constant, so hide only the Windows macro while this
+// header is parsed and restore it immediately afterwards.
+#ifdef PATH
+#pragma push_macro("PATH")
+#undef PATH
+#define CANNONBALL_RESTORE_PATH_MACRO
+#endif
+#include "trackloader.hpp"
+#ifdef CANNONBALL_RESTORE_PATH_MACRO
+#pragma pop_macro("PATH")
+#undef CANNONBALL_RESTORE_PATH_MACRO
+#endif
 
 // Optional external-output transport settings. SmartyPi remains independent.
 struct ExternalOutputSettings
@@ -64,6 +89,11 @@ inline ExternalOutputSettings& external_output_settings()
 class ExternalOutputsWithAttractShowcase : public ExternalOutputs
 {
 public:
+    bool is_showcase_active() const
+    {
+        return showcase_active;
+    }
+
     void update(bool enable_network,
                 bool enable_windows,
                 int port,
@@ -129,8 +159,38 @@ public:
     }
 
 private:
-    static constexpr uint32_t VIEW_TIME = 120; // 4 seconds at the 30 Hz game tick.
+    static constexpr uint32_t VIEW_TIME = 210; // 7 seconds at the 30 Hz game tick.
     static constexpr uint32_t TOTAL_TIME = VIEW_TIME * 3;
+
+    struct AttractResumeSnapshot
+    {
+        ORoad road;
+        OInitEngine initengine;
+        OFerrari ferrari;
+        OSprites sprites;
+        OTraffic traffic;
+        OLevelObjs levelobjs;
+        OAttractAI attractai;
+        OCrash crash;
+        OAnimSeq animseq;
+        OSmoke smoke;
+        OBonus bonus;
+        OStats stats;
+        OPalette palette;
+        OTiles tiles;
+
+        hwtiles hw_tiles;
+        hwsprites hw_sprites;
+        HWRoad hw_road;
+
+        TrackLoader::RuntimeState track;
+        Outrun::AttractRuntimeState attract;
+        std::array<uint16_t, S16_PALETTE_ENTRIES> palette_ram;
+
+        int16_t steering_adjust;
+        uint8_t acc_adjust;
+        uint8_t brake_adjust;
+    };
 
     bool showcase_pending = false;
     bool showcase_active = false;
@@ -144,6 +204,86 @@ private:
     uint8_t phase_view = ORoad::VIEW_ORIGINAL;
     uint32_t showcase_start_tick = 0;
     uint32_t phase_start_tick = 0;
+    std::unique_ptr<AttractResumeSnapshot> resume_state;
+
+    void capture_attract_state()
+    {
+        resume_state.reset(new AttractResumeSnapshot());
+
+        resume_state->road = oroad;
+        resume_state->initengine = oinitengine;
+        resume_state->ferrari = oferrari;
+        resume_state->sprites = osprites;
+        resume_state->traffic = otraffic;
+        resume_state->levelobjs = olevelobjs;
+        resume_state->attractai = oattractai;
+        resume_state->crash = ocrash;
+        resume_state->animseq = oanimseq;
+        resume_state->smoke = osmoke;
+        resume_state->bonus = obonus;
+        resume_state->stats = ostats;
+        resume_state->palette = opalette;
+        resume_state->tiles = otiles;
+
+        resume_state->hw_tiles = *video.tile_layer;
+        resume_state->hw_sprites = *video.sprite_layer;
+        resume_state->hw_road = hwroad;
+
+        resume_state->track = trackloader.capture_runtime_state();
+        resume_state->attract = outrun.capture_attract_runtime_state();
+
+        for (uint32_t i = 0; i < S16_PALETTE_ENTRIES; i++)
+            resume_state->palette_ram[i] =
+                video.read_pal16(S16_PALETTE_BASE + (i << 1));
+
+        resume_state->steering_adjust = oinputs.steering_adjust;
+        resume_state->acc_adjust = oinputs.acc_adjust;
+        resume_state->brake_adjust = oinputs.brake_adjust;
+    }
+
+    void restore_attract_state()
+    {
+        if (!resume_state)
+            return;
+
+        // Restore the software-side engine first. Ferrari/traffic/crash objects
+        // contain pointers into the global OSprites table, whose address never
+        // changes; restoring OSprites puts the pointed-to entries back in place.
+        osprites = resume_state->sprites;
+        oroad = resume_state->road;
+        oinitengine = resume_state->initengine;
+        oferrari = resume_state->ferrari;
+        otraffic = resume_state->traffic;
+        olevelobjs = resume_state->levelobjs;
+        oattractai = resume_state->attractai;
+        ocrash = resume_state->crash;
+        oanimseq = resume_state->animseq;
+        osmoke = resume_state->smoke;
+        obonus = resume_state->bonus;
+        ostats = resume_state->stats;
+        opalette = resume_state->palette;
+        otiles = resume_state->tiles;
+
+        trackloader.restore_runtime_state(resume_state->track);
+        outrun.restore_attract_runtime_state(resume_state->attract);
+
+        // Restore the emulated video hardware too. This is what makes resuming
+        // work even if the normal attract had already reached a later stage,
+        // palette transition or road split before High Scores / Logo appeared.
+        *video.tile_layer = resume_state->hw_tiles;
+        *video.sprite_layer = resume_state->hw_sprites;
+        hwroad = resume_state->hw_road;
+
+        uint32_t pal_addr = S16_PALETTE_BASE;
+        for (uint32_t i = 0; i < S16_PALETTE_ENTRIES; i++)
+            video.write_pal16(&pal_addr, resume_state->palette_ram[i]);
+
+        oinputs.steering_adjust = resume_state->steering_adjust;
+        oinputs.acc_adjust = resume_state->acc_adjust;
+        oinputs.brake_adjust = resume_state->brake_adjust;
+
+        resume_state.reset();
+    }
 
     void clear_double_row(uint8_t y)
     {
@@ -248,9 +388,9 @@ private:
 
     void reset_showcase_segment(uint8_t view)
     {
-        // Reuse the first few seconds of Coconut Beach for every camera. This
-        // keeps all three comparisons on the same straight road section and
-        // avoids ever reaching the first bend during the 12-second showcase.
+        // Reuse the opening Coconut Beach straight for every camera. Each
+        // seven-second section starts from the same point, so all views get a
+        // directly comparable road scene without reaching the first bend.
         oroad.init();
         oinitengine.init(0);
 
@@ -290,22 +430,42 @@ private:
         showcase_active = true;
         showcase_phase = 0;
         showcase_start_tick = outrun.tick_counter;
+
+        // GS_INIT has just restored the normal Enhanced Attract to the point at
+        // which it stopped before High Scores / Logo. Freeze that exact runtime
+        // state here, use the live engine for the disposable showcase, then put
+        // this snapshot back afterwards.
+        capture_attract_state();
+
         video.clear_text_ram();
         reset_showcase_segment(ORoad::VIEW_ORIGINAL);
     }
 
     void end_showcase()
     {
+        restore_attract_state();
+
         showcase_active = false;
         showcase_phase = -1;
         manual_override = false;
-        video.clear_text_ram();
-        oroad.set_view_mode(ORoad::VIEW_ORIGINAL, true);
-        otraffic.set_max_traffic();
 
-        // GS_INIT restarts the existing enhanced attract timer/view sequence on
-        // the next engine tick. No normal attract behaviour is replaced.
-        outrun.game_state = GS_INIT;
+        // Continue the already-resumed Enhanced Attract directly. Do not enter
+        // GS_INIT again: doing so would reset its timer/view sequence instead of
+        // carrying on from the state captured immediately after the logo.
+        outrun.game_state = GS_ATTRACT;
+    }
+
+    void abort_showcase(bool restore_attract)
+    {
+        if (restore_attract)
+            restore_attract_state();
+        else
+            resume_state.reset();
+
+        showcase_active = false;
+        showcase_pending = false;
+        showcase_phase = -1;
+        manual_override = false;
     }
 
     void update_showcase()
@@ -334,11 +494,12 @@ private:
         {
             if (!enhanced_game || outrun.game_state != GS_ATTRACT)
             {
-                showcase_active = false;
-                showcase_pending = false;
-                showcase_phase = -1;
-                manual_override = false;
-                otraffic.set_max_traffic();
+                // If the player inserted a credit, the game has legitimately
+                // left Attract for Music Select; do not overwrite that state.
+                // If Enhanced Attract itself was merely disabled while we are
+                // still in GS_ATTRACT, put the pre-showcase scene back first.
+                const bool can_restore = outrun.game_state == GS_ATTRACT;
+                abort_showcase(can_restore);
             }
             else
             {
@@ -371,7 +532,7 @@ private:
                         // The existing Enhanced Attract view timer still ticks
                         // underneath us. Hold the showcase's intended automatic
                         // view against that timer, but never fight a real player
-                        // VR-button override inside the current 4-second phase.
+                        // VR-button override inside the current seven-second phase.
                         if (!manual_override && oroad.get_view_mode() != phase_view)
                             oroad.set_view_mode(phase_view, true);
                     }

--- a/src/main/engine/external_output_settings.hpp
+++ b/src/main/engine/external_output_settings.hpp
@@ -16,6 +16,7 @@
 #include "engine/otraffic.hpp"
 #include "frontend/config.hpp"
 #include "frontend/xml_parser.h"
+#include "sdl2/input.hpp"
 
 // Optional external-output transport settings. SmartyPi remains independent.
 struct ExternalOutputSettings
@@ -129,12 +130,16 @@ public:
     }
 
 private:
-    static const uint32_t VIEW_TIME = 120; // 4 seconds at the 30 Hz game tick.
-    static const uint32_t TOTAL_TIME = VIEW_TIME * 3;
+    static constexpr uint32_t VIEW_TIME = 120; // 4 seconds at the 30 Hz game tick.
+    static constexpr uint32_t TOTAL_TIME = VIEW_TIME * 3;
 
     bool showcase_pending = false;
     bool showcase_active = false;
     bool manual_override = false;
+    bool view1_old = false;
+    bool view2_old = false;
+    bool view3_old = false;
+    bool viewpoint_old = false;
     int previous_game_state = -1;
     int showcase_phase = -1;
     uint8_t phase_view = ORoad::VIEW_ORIGINAL;
@@ -197,7 +202,7 @@ private:
         if (view == ORoad::VIEW_ELEVATED)
             view_name = "ELEVATED VIEW";
         else if (view == ORoad::VIEW_INCAR)
-            view_name = "IN-CAR VIEW";
+            view_name = "IN CAR VIEW";
 
         // Same yellow/black double-row style as the enhanced Music Select song
         // title. The selected view deliberately blinks like an arcade prompt.
@@ -205,6 +210,26 @@ private:
             draw_double_row_centered(7, view_name, 0x8AA0);
         else
             clear_double_row(7);
+    }
+
+    bool manual_view_pressed()
+    {
+        const bool view1 = input.is_pressed(Input::VIEW1);
+        const bool view2 = input.is_pressed(Input::VIEW2);
+        const bool view3 = input.is_pressed(Input::VIEW3);
+        const bool viewpoint = input.is_pressed(Input::VIEWPOINT);
+
+        const bool pressed =
+            (view1 && !view1_old) ||
+            (view2 && !view2_old) ||
+            (view3 && !view3_old) ||
+            (viewpoint && !viewpoint_old);
+
+        view1_old = view1;
+        view2_old = view2;
+        view3_old = view3;
+        viewpoint_old = viewpoint;
+        return pressed;
     }
 
     void hide_non_palm_opening_scenery()
@@ -339,22 +364,29 @@ private:
                         showcase_phase = phase;
                         reset_showcase_segment(VIEWS[phase]);
                     }
-                    else if (oroad.get_view_mode() != phase_view)
+                    else
                     {
-                        // OOutputs already processed the cabinet/player VR
-                        // button before this wrapper runs, so a mismatch here is
-                        // a real manual override. Keep it until the next phase.
-                        manual_override = true;
+                        if (manual_view_pressed())
+                            manual_override = true;
+
+                        // The existing Enhanced Attract view timer still ticks
+                        // underneath us. Hold the showcase's intended automatic
+                        // view against that timer, but never fight a real player
+                        // VR-button override inside the current 4-second phase.
+                        if (!manual_override && oroad.get_view_mode() != phase_view)
+                            oroad.set_view_mode(phase_view, true);
                     }
 
-                    // Keep the demonstration pinned to full speed and centreline
-                    // regardless of normal AI braking/collision decisions.
+                    // Keep the demonstration pinned to full speed, normal road
+                    // width and centreline regardless of AI/collision decisions.
                     oinitengine.car_increment = 0xFA << 16;
                     oferrari.car_inc_old = 0xFA;
                     oinitengine.car_x_pos = 0;
                     oinputs.acc_adjust = 0xFF;
                     oinputs.brake_adjust = 0;
                     oinputs.steering_adjust = 0;
+                    oroad.road_width = 0xD4 << 16;
+                    oroad.road_width_bak = 0xD4;
                     otraffic.disable_traffic();
                     otraffic.set_custom_max_traffic(0);
                     otraffic.ai_traffic = 0;
@@ -362,6 +394,12 @@ private:
                     draw_showcase_text();
                 }
             }
+        }
+        else
+        {
+            // Keep edge trackers current outside the showcase so holding a VR
+            // button across the transition cannot look like a fresh press.
+            manual_view_pressed();
         }
 
         previous_game_state = outrun.game_state;

--- a/src/main/engine/external_output_settings.hpp
+++ b/src/main/engine/external_output_settings.hpp
@@ -270,9 +270,9 @@ private:
         phase_time = Clock::now();
         phase_start_frame = cannonball::frame;
 
-        // The car keeps the exact speed/input state produced by Enhanced Attract.
-        // We only switch the camera. A road pass re-renders the same road position
-        // with the new snapped horizon before the short presentation freeze.
+        // Preserve the exact native Enhanced Attract vehicle state. We never
+        // write car_increment, accelerator, brake or steering here. The road
+        // pass only rebuilds the same road position with the snapped camera.
         oroad.set_view_mode(phase_view, true);
         oroad.tick();
         pause_engine = true;

--- a/src/main/engine/external_output_settings.hpp
+++ b/src/main/engine/external_output_settings.hpp
@@ -1,46 +1,22 @@
 #pragma once
 
-#include <array>
+#include <chrono>
 #include <cstring>
-#include <memory>
 #include <string>
 
 #include "main.hpp"
 #include "roms.hpp"
 #include "video.hpp"
-#include "engine/oanimseq.hpp"
-#include "engine/oattractai.hpp"
-#include "engine/obonus.hpp"
-#include "engine/ocrash.hpp"
-#include "engine/oferrari.hpp"
 #include "engine/ohud.hpp"
-#include "engine/oinitengine.hpp"
-#include "engine/oinputs.hpp"
-#include "engine/olevelobjs.hpp"
-#include "engine/opalette.hpp"
 #include "engine/oroad.hpp"
-#include "engine/osmoke.hpp"
-#include "engine/osprites.hpp"
-#include "engine/ostats.hpp"
-#include "engine/otiles.hpp"
-#include "engine/otraffic.hpp"
+#include "engine/outrun.hpp"
 #include "frontend/config.hpp"
 #include "frontend/xml_parser.h"
 #include "sdl2/input.hpp"
 
-// windows.h defines PATH in some SDK configurations. TrackLoader also has the
-// legitimate LayOut::PATH constant, so hide only the Windows macro while this
-// header is parsed and restore it immediately afterwards.
-#ifdef PATH
-#pragma push_macro("PATH")
-#undef PATH
-#define CANNONBALL_RESTORE_PATH_MACRO
-#endif
-#include "trackloader.hpp"
-#ifdef CANNONBALL_RESTORE_PATH_MACRO
-#pragma pop_macro("PATH")
-#undef CANNONBALL_RESTORE_PATH_MACRO
-#endif
+// Main engine pause flag. The showcase owns this only for its short camera
+// presentation freezes; audio and rendering continue normally.
+extern bool pause_engine;
 
 // Optional external-output transport settings. SmartyPi remains independent.
 struct ExternalOutputSettings
@@ -83,9 +59,9 @@ inline ExternalOutputSettings& external_output_settings()
     return settings;
 }
 
-// Enhanced-attract showcase wrapper. external_outputs.hpp is included before
-// this header, so deriving here lets the existing OOutputs call site remain
-// untouched while the showcase can override the final lamp values.
+// Enhanced-attract showcase wrapper. The normal Enhanced Attract drive is
+// reused directly: after High Scores / Logo the car continues from the same
+// road position and the three camera views are presented on that live scene.
 class ExternalOutputsWithAttractShowcase : public ExternalOutputs
 {
 public:
@@ -115,7 +91,7 @@ public:
             view2_lamp = 0;
             view3_lamp = 0;
 
-            const bool fast_blink = (outrun.tick_counter & BIT_3) != 0;
+            const bool fast_blink = (cannonball::frame & 0x08) != 0;
             const uint8_t view = oroad.get_view_mode();
 
             if (view == ORoad::VIEW_ORIGINAL)
@@ -126,10 +102,9 @@ public:
                 }
                 else
                 {
-                    // Automatic ORIGINAL uses the same fast ping-pong chase as
-                    // the enhanced attract mode: 1 -> 2 -> 3 -> 2 -> ...
+                    // Automatic ORIGINAL uses the existing ping-pong lamp chase.
                     const uint8_t chase =
-                        static_cast<uint8_t>(((outrun.tick_counter - phase_start_tick) >> 3) & 3);
+                        static_cast<uint8_t>(((cannonball::frame - phase_start_frame) >> 3) & 3);
                     view1_lamp = chase == 0 ? 1 : 0;
                     view2_lamp = (chase == 1 || chase == 3) ? 1 : 0;
                     view3_lamp = chase == 2 ? 1 : 0;
@@ -159,41 +134,14 @@ public:
     }
 
 private:
-    static constexpr uint32_t VIEW_TIME = 210; // 7 seconds at the 30 Hz game tick.
-    static constexpr uint32_t TOTAL_TIME = VIEW_TIME * 3;
+    using Clock = std::chrono::steady_clock;
 
-    struct AttractResumeSnapshot
-    {
-        ORoad road;
-        OInitEngine initengine;
-        OFerrari ferrari;
-        OSprites sprites;
-        OTraffic traffic;
-        OLevelObjs levelobjs;
-        OAttractAI attractai;
-        OCrash crash;
-        OAnimSeq animseq;
-        OSmoke smoke;
-        OBonus bonus;
-        OStats stats;
-        OPalette palette;
-        OTiles tiles;
-
-        hwtiles hw_tiles;
-        hwsprites hw_sprites;
-        HWRoad hw_road;
-
-        TrackLoader::RuntimeState track;
-        Outrun::AttractRuntimeState attract;
-        std::array<uint16_t, S16_PALETTE_ENTRIES> palette_ram;
-
-        int16_t steering_adjust;
-        uint8_t acc_adjust;
-        uint8_t brake_adjust;
-    };
+    static constexpr std::chrono::milliseconds FREEZE_TIME{900};
+    static constexpr std::chrono::seconds DRIVE_TIME{7};
 
     bool showcase_pending = false;
     bool showcase_active = false;
+    bool showcase_freezing = false;
     bool manual_override = false;
     bool view1_old = false;
     bool view2_old = false;
@@ -202,88 +150,10 @@ private:
     int previous_game_state = -1;
     int showcase_phase = -1;
     uint8_t phase_view = ORoad::VIEW_ORIGINAL;
-    uint32_t showcase_start_tick = 0;
-    uint32_t phase_start_tick = 0;
-    std::unique_ptr<AttractResumeSnapshot> resume_state;
-
-    void capture_attract_state()
-    {
-        resume_state.reset(new AttractResumeSnapshot());
-
-        resume_state->road = oroad;
-        resume_state->initengine = oinitengine;
-        resume_state->ferrari = oferrari;
-        resume_state->sprites = osprites;
-        resume_state->traffic = otraffic;
-        resume_state->levelobjs = olevelobjs;
-        resume_state->attractai = oattractai;
-        resume_state->crash = ocrash;
-        resume_state->animseq = oanimseq;
-        resume_state->smoke = osmoke;
-        resume_state->bonus = obonus;
-        resume_state->stats = ostats;
-        resume_state->palette = opalette;
-        resume_state->tiles = otiles;
-
-        resume_state->hw_tiles = *video.tile_layer;
-        resume_state->hw_sprites = *video.sprite_layer;
-        resume_state->hw_road = hwroad;
-
-        resume_state->track = trackloader.capture_runtime_state();
-        resume_state->attract = outrun.capture_attract_runtime_state();
-
-        for (uint32_t i = 0; i < S16_PALETTE_ENTRIES; i++)
-            resume_state->palette_ram[i] =
-                video.read_pal16(S16_PALETTE_BASE + (i << 1));
-
-        resume_state->steering_adjust = oinputs.steering_adjust;
-        resume_state->acc_adjust = oinputs.acc_adjust;
-        resume_state->brake_adjust = oinputs.brake_adjust;
-    }
-
-    void restore_attract_state()
-    {
-        if (!resume_state)
-            return;
-
-        // Restore the software-side engine first. Ferrari/traffic/crash objects
-        // contain pointers into the global OSprites table, whose address never
-        // changes; restoring OSprites puts the pointed-to entries back in place.
-        osprites = resume_state->sprites;
-        oroad = resume_state->road;
-        oinitengine = resume_state->initengine;
-        oferrari = resume_state->ferrari;
-        otraffic = resume_state->traffic;
-        olevelobjs = resume_state->levelobjs;
-        oattractai = resume_state->attractai;
-        ocrash = resume_state->crash;
-        oanimseq = resume_state->animseq;
-        osmoke = resume_state->smoke;
-        obonus = resume_state->bonus;
-        ostats = resume_state->stats;
-        opalette = resume_state->palette;
-        otiles = resume_state->tiles;
-
-        trackloader.restore_runtime_state(resume_state->track);
-        outrun.restore_attract_runtime_state(resume_state->attract);
-
-        // Restore the emulated video hardware too. This is what makes resuming
-        // work even if the normal attract had already reached a later stage,
-        // palette transition or road split before High Scores / Logo appeared.
-        *video.tile_layer = resume_state->hw_tiles;
-        *video.sprite_layer = resume_state->hw_sprites;
-        hwroad = resume_state->hw_road;
-
-        uint32_t pal_addr = S16_PALETTE_BASE;
-        for (uint32_t i = 0; i < S16_PALETTE_ENTRIES; i++)
-            video.write_pal16(&pal_addr, resume_state->palette_ram[i]);
-
-        oinputs.steering_adjust = resume_state->steering_adjust;
-        oinputs.acc_adjust = resume_state->acc_adjust;
-        oinputs.brake_adjust = resume_state->brake_adjust;
-
-        resume_state.reset();
-    }
+    uint32_t phase_start_frame = 0;
+    Clock::time_point phase_time{};
+    Outrun::AttractRuntimeState attract_cycle_state{};
+    bool attract_cycle_saved = false;
 
     void clear_double_row(uint8_t y)
     {
@@ -343,9 +213,9 @@ private:
         else if (view == ORoad::VIEW_INCAR)
             view_name = "IN CAR VIEW";
 
-        // Same yellow/black double-row style as the enhanced Music Select song
-        // title. The selected view deliberately blinks like an arcade prompt.
-        if (outrun.tick_counter & BIT_4)
+        // Keep the name solid during the short freeze so the changed camera is
+        // clearly explained. Once driving resumes it returns to the arcade blink.
+        if (showcase_freezing || (cannonball::frame & 0x10))
             draw_double_row_centered(7, view_name, 0x8AA0);
         else
             clear_double_row(7);
@@ -371,101 +241,71 @@ private:
         return pressed;
     }
 
-    void hide_non_palm_opening_scenery()
+    void begin_view_phase(int phase)
     {
-        // Stage 1's palm trees use the normal level-object routine. Hide the
-        // special start-line/water/grass/cloud routines so the short showcase
-        // reads as road + palms rather than a normal attract-stage scene.
-        // Limit this to the stage-1 level-object slots; Ferrari/passenger/smoke
-        // slots live outside this range and remain untouched.
-        for (int i = 0; i <= 0x44; i++)
+        static const uint8_t VIEWS[] =
         {
-            oentry* sprite = &osprites.jump_table[i];
-            if ((sprite->control & OSprites::ENABLE) && sprite->function_holder != 0)
-                sprite->control &= ~OSprites::ENABLE;
-        }
-    }
+            ORoad::VIEW_ORIGINAL,
+            ORoad::VIEW_ELEVATED,
+            ORoad::VIEW_INCAR,
+        };
 
-    void reset_showcase_segment(uint8_t view)
-    {
-        // Reuse the opening Coconut Beach straight for every camera. Each
-        // seven-second section starts from the same point, so all views get a
-        // directly comparable road scene without reaching the first bend.
-        oroad.init();
-        oinitengine.init(0);
-
-        oferrari.car_ctrl_active = true;
-        oinitengine.car_x_pos = 0;
-        oinitengine.car_x_old = 0;
-        oroad.car_x_bak = 0;
-
-        // Start at full normal OutRun speed instead of accelerating from rest.
-        oinitengine.car_increment = 0xFA << 16;
-        oferrari.car_inc_old = 0xFA;
-        oinputs.acc_adjust = 0xFF;
-        oinputs.brake_adjust = 0;
-        oinputs.steering_adjust = 0;
-
-        // Present a normal single road immediately, without the wide start-grid
-        // road geometry, and suppress every traffic slot/spawn during the demo.
-        oroad.road_width = 0xD4 << 16;
-        oroad.road_width_bak = 0xD4;
-        otraffic.disable_traffic();
-        otraffic.set_custom_max_traffic(0);
-        otraffic.ai_traffic = 0;
-
-        // Remove any hard-coded start-line objects left in the reusable slots.
-        for (int i = 0; i <= 0x44; i++)
-            osprites.jump_table[i].control &= ~OSprites::ENABLE;
-
-        oroad.set_view_mode(view, true);
-        phase_view = view;
+        showcase_phase = phase;
+        phase_view = VIEWS[phase];
         manual_override = false;
-        phase_start_tick = outrun.tick_counter;
+        showcase_freezing = true;
+        phase_time = Clock::now();
+        phase_start_frame = cannonball::frame;
+
+        // Switch the camera while the live road is still at the exact frame we
+        // just displayed. One road pass applies the new horizon immediately;
+        // the following short engine pause then holds that transformed scene.
+        oroad.set_view_mode(phase_view, true);
+        oroad.tick();
+        pause_engine = true;
     }
 
     void start_showcase()
     {
         showcase_pending = false;
         showcase_active = true;
-        showcase_phase = 0;
-        showcase_start_tick = outrun.tick_counter;
-
-        // GS_INIT has just restored the normal Enhanced Attract to the point at
-        // which it stopped before High Scores / Logo. Freeze that exact runtime
-        // state here, use the live engine for the disposable showcase, then put
-        // this snapshot back afterwards.
-        capture_attract_state();
-
+        attract_cycle_state = outrun.capture_attract_runtime_state();
+        attract_cycle_saved = true;
         video.clear_text_ram();
-        reset_showcase_segment(ORoad::VIEW_ORIGINAL);
+        begin_view_phase(0);
     }
 
-    void end_showcase()
+    void finish_showcase()
     {
-        restore_attract_state();
+        pause_engine = false;
+        showcase_freezing = false;
 
+        // The normal Enhanced Attract view timer has continued in the background
+        // during the moving sections. Re-sync it to the camera we actually end
+        // on, so its next automatic change starts a fresh, predictable cycle.
+        if (attract_cycle_saved)
+        {
+            attract_cycle_state.view = oroad.get_view_mode();
+            attract_cycle_state.counter = 0;
+            outrun.restore_attract_runtime_state(attract_cycle_state);
+        }
+
+        attract_cycle_saved = false;
         showcase_active = false;
         showcase_phase = -1;
         manual_override = false;
-
-        // Continue the already-resumed Enhanced Attract directly. Do not enter
-        // GS_INIT again: doing so would reset its timer/view sequence instead of
-        // carrying on from the state captured immediately after the logo.
-        outrun.game_state = GS_ATTRACT;
+        video.clear_text_ram();
     }
 
-    void abort_showcase(bool restore_attract)
+    void abort_showcase()
     {
-        if (restore_attract)
-            restore_attract_state();
-        else
-            resume_state.reset();
-
+        pause_engine = false;
         showcase_active = false;
         showcase_pending = false;
+        showcase_freezing = false;
         showcase_phase = -1;
         manual_override = false;
+        attract_cycle_saved = false;
     }
 
     void update_showcase()
@@ -475,7 +315,7 @@ private:
             config.engine.new_attract;
 
         // Logo timeout changes GS_LOGO -> GS_INIT for one frame. Remember that
-        // edge, then start only when GS_INIT has entered GS_ATTRACT next tick.
+        // edge, then start only once GS_INIT has resumed the real attract drive.
         if (enhanced_game &&
             previous_game_state == GS_LOGO &&
             outrun.game_state == GS_INIT)
@@ -494,71 +334,59 @@ private:
         {
             if (!enhanced_game || outrun.game_state != GS_ATTRACT)
             {
-                // If the player inserted a credit, the game has legitimately
-                // left Attract for Music Select; do not overwrite that state.
-                // If Enhanced Attract itself was merely disabled while we are
-                // still in GS_ATTRACT, put the pre-showcase scene back first.
-                const bool can_restore = outrun.game_state == GS_ATTRACT;
-                abort_showcase(can_restore);
+                abort_showcase();
             }
             else
             {
-                const uint32_t elapsed = outrun.tick_counter - showcase_start_tick;
+                const Clock::time_point now = Clock::now();
 
-                if (elapsed >= TOTAL_TIME)
+                if (showcase_freezing)
                 {
-                    end_showcase();
+                    // Ignore manual VR changes during the explanatory freeze;
+                    // the announced view owns this short presentation moment.
+                    manual_view_pressed();
+                    if (oroad.get_view_mode() != phase_view)
+                    {
+                        oroad.set_view_mode(phase_view, true);
+                        oroad.tick();
+                    }
+
+                    draw_showcase_text();
+
+                    if (now - phase_time >= FREEZE_TIME)
+                    {
+                        showcase_freezing = false;
+                        pause_engine = false;
+                        phase_time = now;
+                    }
                 }
                 else
                 {
-                    const int phase = static_cast<int>(elapsed / VIEW_TIME);
-                    static const uint8_t VIEWS[] =
-                    {
-                        ORoad::VIEW_ORIGINAL,
-                        ORoad::VIEW_ELEVATED,
-                        ORoad::VIEW_INCAR,
-                    };
+                    if (manual_view_pressed())
+                        manual_override = true;
 
-                    if (phase != showcase_phase)
-                    {
-                        showcase_phase = phase;
-                        reset_showcase_segment(VIEWS[phase]);
-                    }
-                    else
-                    {
-                        if (manual_view_pressed())
-                            manual_override = true;
+                    // The existing Enhanced Attract timer may try to change the
+                    // view underneath the presentation. Hold the announced view
+                    // unless the player deliberately used a VR button.
+                    if (!manual_override && oroad.get_view_mode() != phase_view)
+                        oroad.set_view_mode(phase_view, true);
 
-                        // The existing Enhanced Attract view timer still ticks
-                        // underneath us. Hold the showcase's intended automatic
-                        // view against that timer, but never fight a real player
-                        // VR-button override inside the current seven-second phase.
-                        if (!manual_override && oroad.get_view_mode() != phase_view)
-                            oroad.set_view_mode(phase_view, true);
-                    }
-
-                    // Keep the demonstration pinned to full speed, normal road
-                    // width and centreline regardless of AI/collision decisions.
-                    oinitengine.car_increment = 0xFA << 16;
-                    oferrari.car_inc_old = 0xFA;
-                    oinitengine.car_x_pos = 0;
-                    oinputs.acc_adjust = 0xFF;
-                    oinputs.brake_adjust = 0;
-                    oinputs.steering_adjust = 0;
-                    oroad.road_width = 0xD4 << 16;
-                    oroad.road_width_bak = 0xD4;
-                    otraffic.disable_traffic();
-                    otraffic.set_custom_max_traffic(0);
-                    otraffic.ai_traffic = 0;
-                    hide_non_palm_opening_scenery();
                     draw_showcase_text();
+
+                    if (now - phase_time >= DRIVE_TIME)
+                    {
+                        if (showcase_phase < 2)
+                            begin_view_phase(showcase_phase + 1);
+                        else
+                            finish_showcase();
+                    }
                 }
             }
         }
         else
         {
-            // Keep edge trackers current outside the showcase so holding a VR
-            // button across the transition cannot look like a fresh press.
+            // Keep edge trackers current outside the showcase so a held VR
+            // button cannot become a false new press at the next presentation.
             manual_view_pressed();
         }
 

--- a/src/main/engine/external_output_settings.hpp
+++ b/src/main/engine/external_output_settings.hpp
@@ -221,7 +221,9 @@ private:
         draw_double_row_centered(2, "TRY THREE DIFFERENT VIEWS", prompt_pal);
         draw_double_row_centered(4, "WITH THE VR BUTTONS!", prompt_pal);
 
-        if (cannonball::frame & 0x10)
+        // Use the exact same fast BIT_3 cadence as the active showcase lamp so
+        // the label and physical button light blink visibly in lockstep.
+        if (cannonball::frame & 0x08)
             draw_double_row_centered(7, phase_view_name(), 0x8AA0);
         else
             clear_double_row(7);

--- a/src/main/engine/external_output_settings.hpp
+++ b/src/main/engine/external_output_settings.hpp
@@ -80,6 +80,7 @@ public:
                 int view3_lamp)
     {
         update_showcase();
+        reset_view_on_start();
 
         if (showcase_active)
         {
@@ -141,6 +142,7 @@ private:
 
     bool showcase_active = false;
     bool showcase_announcing = false;
+    bool start_old = false;
 
     // Every real GS_ATTRACT driving section gets one midpoint showcase. After a
     // Logo -> Attract transition it additionally gets one early showcase after
@@ -250,6 +252,26 @@ private:
         view3_old = view3;
         viewpoint_old = viewpoint;
         return pressed;
+    }
+
+    void reset_view_on_start()
+    {
+        const bool start_now = input.is_pressed(Input::START);
+
+        // START always wins over attract/showcase camera state. Limit the reset
+        // to pre-race states so START cannot unexpectedly change the camera
+        // during an active run.
+        if (start_now && !start_old &&
+            cannonball::state == cannonball::STATE_GAME &&
+            (outrun.game_state < GS_START1 || outrun.game_state == GS_BEST2))
+        {
+            if (showcase_active)
+                abort_showcase();
+
+            oroad.set_view_mode(ORoad::VIEW_ORIGINAL, true);
+        }
+
+        start_old = start_now;
     }
 
     bool tick_due(uint32_t due) const

--- a/src/main/engine/external_output_settings.hpp
+++ b/src/main/engine/external_output_settings.hpp
@@ -141,7 +141,6 @@ private:
 
     bool showcase_active = false;
     bool showcase_announcing = false;
-    bool manual_override = false;
 
     // Every real GS_ATTRACT driving section gets one midpoint showcase. After a
     // Logo -> Attract transition it additionally gets one early showcase after
@@ -270,7 +269,6 @@ private:
         showcase_phase = phase;
         phase_view = VIEWS[phase];
         announcement_hold_view = oroad.get_view_mode();
-        manual_override = false;
         showcase_announcing = true;
         phase_start_frame = cannonball::frame;
         phase_due_tick = outrun.tick_counter + ANNOUNCE_TIME_TICKS;
@@ -279,7 +277,6 @@ private:
     void apply_announced_view()
     {
         showcase_announcing = false;
-        manual_override = false;
 
         // Camera change only. Vehicle speed, AI, traffic, road position and all
         // other Enhanced Attract logic continue exactly as they normally would.
@@ -313,7 +310,6 @@ private:
         attract_cycle_saved = false;
         showcase_active = false;
         showcase_phase = -1;
-        manual_override = false;
         video.clear_text_ram();
     }
 
@@ -322,7 +318,6 @@ private:
         showcase_active = false;
         showcase_announcing = false;
         showcase_phase = -1;
-        manual_override = false;
         attract_cycle_saved = false;
     }
 
@@ -401,15 +396,17 @@ private:
             }
             else
             {
-                if (manual_view_pressed())
-                    manual_override = true;
+                // Consume all view-button edges while the presentation owns the
+                // camera. This keeps held buttons from becoming a fresh input as
+                // soon as the showcase ends, but no view input is acted upon.
+                manual_view_pressed();
 
                 if (showcase_announcing)
                 {
-                    // Keep the live view stable against the normal automatic
-                    // Enhanced Attract view timer while the next view is being
-                    // announced. A real VR-button press is still respected.
-                    if (!manual_override && oroad.get_view_mode() != announcement_hold_view)
+                    // Keep the currently displayed camera fixed during the
+                    // two-second announcement. Automatic attract changes and
+                    // player view-button changes are both ignored here.
+                    if (oroad.get_view_mode() != announcement_hold_view)
                         oroad.set_view_mode(announcement_hold_view, true);
 
                     draw_showcase_text();
@@ -419,9 +416,9 @@ private:
                 }
                 else
                 {
-                    // During the six-second demonstration hold the announced
-                    // automatic view, but never fight a real player VR override.
-                    if (!manual_override && oroad.get_view_mode() != phase_view)
+                    // During the six-second demonstration the announced view
+                    // owns the camera. All VIEW1/2/3/VIEWPOINT input is ignored.
+                    if (oroad.get_view_mode() != phase_view)
                         oroad.set_view_mode(phase_view, true);
 
                     draw_showcase_text();

--- a/src/main/engine/external_output_settings.hpp
+++ b/src/main/engine/external_output_settings.hpp
@@ -5,7 +5,6 @@
 
 #include "main.hpp"
 #include "roms.hpp"
-#include "trackloader.hpp"
 #include "video.hpp"
 #include "engine/oferrari.hpp"
 #include "engine/ohud.hpp"

--- a/src/main/engine/external_output_settings.hpp
+++ b/src/main/engine/external_output_settings.hpp
@@ -58,7 +58,7 @@ inline ExternalOutputSettings& external_output_settings()
 
 // Enhanced-attract showcase wrapper. The normal Enhanced Attract drive is
 // reused directly: no demo level, speed override, traffic override, road reset
-// or engine pause is used. Each camera is announced first, then applied while
+// or engine pause is used. Camera, view name and lamp change together while
 // the live attract drive continues uninterrupted.
 class ExternalOutputsWithAttractShowcase : public ExternalOutputs
 {
@@ -85,7 +85,7 @@ public:
         if (showcase_active)
         {
             // The dedicated VR lamps always follow the camera that is actually
-            // on screen, including during the two-second announcement period.
+            // on screen. View, label and lamp switch in the same update tick.
             view_lamp = 0;
             view1_lamp = 0;
             view2_lamp = 0;
@@ -125,10 +125,9 @@ public:
     }
 
 private:
-    // Each view is announced for two seconds while the previous live camera
-    // continues to drive, then demonstrated for six seconds after the switch.
-    static constexpr uint32_t ANNOUNCE_TIME_TICKS = 60; // 2 seconds at 30 Hz.
-    static constexpr uint32_t VIEW_TIME_TICKS = 180;    // 6 seconds at 30 Hz.
+    // Each showcased camera is active for six seconds. There is deliberately no
+    // announcement lead-in: camera, name and lamp all change together.
+    static constexpr uint32_t VIEW_TIME_TICKS = 180; // 6 seconds at 30 Hz.
 
     // Enhanced Attract starts each driving section at BCD 0x80 (80 seconds).
     // Trigger the in-section presentation at the real halfway point: 40 seconds
@@ -141,7 +140,6 @@ private:
     static constexpr uint32_t POST_LOGO_DELAY_TICKS = 135; // 4.5 seconds at 30 Hz.
 
     bool showcase_active = false;
-    bool showcase_announcing = false;
     bool start_old = false;
 
     // Every real GS_ATTRACT driving section gets one midpoint showcase. After a
@@ -159,7 +157,6 @@ private:
     int previous_game_state = -1;
     int showcase_phase = -1;
     uint8_t phase_view = ORoad::VIEW_ORIGINAL;
-    uint8_t announcement_hold_view = ORoad::VIEW_ORIGINAL;
     uint32_t phase_due_tick = 0;
     Outrun::AttractRuntimeState attract_cycle_state{};
     bool attract_cycle_saved = false;
@@ -224,10 +221,7 @@ private:
         draw_double_row_centered(2, "TRY THREE DIFFERENT VIEWS", prompt_pal);
         draw_double_row_centered(4, "WITH THE VR BUTTONS!", prompt_pal);
 
-        // During the two-second lead-in the upcoming view name is held solid so
-        // the player reads the explanation before the camera actually changes.
-        // Once the view is active, the name returns to the arcade-style blink.
-        if (showcase_announcing || (cannonball::frame & 0x10))
+        if (cannonball::frame & 0x10)
             draw_double_row_centered(7, phase_view_name(), 0x8AA0);
         else
             clear_double_row(7);
@@ -277,17 +271,10 @@ private:
 
         showcase_phase = phase;
         phase_view = VIEWS[phase];
-        announcement_hold_view = oroad.get_view_mode();
-        showcase_announcing = true;
-        phase_due_tick = outrun.tick_counter + ANNOUNCE_TIME_TICKS;
-    }
 
-    void apply_announced_view()
-    {
-        showcase_announcing = false;
-
-        // Camera change only. Vehicle speed, AI, traffic, road position and all
-        // other Enhanced Attract logic continue exactly as they normally would.
+        // Apply the camera immediately. The text below already uses phase_view
+        // and the output wrapper reads oroad.get_view_mode(), so name, camera
+        // and dedicated lamp all change together on this same showcase tick.
         oroad.set_view_mode(phase_view, true);
         phase_due_tick = outrun.tick_counter + VIEW_TIME_TICKS;
     }
@@ -303,8 +290,6 @@ private:
 
     void finish_showcase()
     {
-        showcase_announcing = false;
-
         // Re-sync the normal automatic view timer to the view on screen so the
         // next automatic attract change starts a fresh, predictable cycle.
         if (attract_cycle_saved)
@@ -323,7 +308,6 @@ private:
     void abort_showcase()
     {
         showcase_active = false;
-        showcase_announcing = false;
         showcase_phase = -1;
         attract_cycle_saved = false;
         video.clear_text_ram();
@@ -409,35 +393,19 @@ private:
                 // input as soon as the showcase ends.
                 sync_view_button_states();
 
-                if (showcase_announcing)
+                // Keep the announced view authoritative against the normal
+                // automatic Enhanced Attract cycle and ignored player inputs.
+                if (oroad.get_view_mode() != phase_view)
+                    oroad.set_view_mode(phase_view, true);
+
+                draw_showcase_text();
+
+                if (tick_due(phase_due_tick))
                 {
-                    // Keep the currently displayed camera fixed during the
-                    // two-second announcement. Automatic attract changes and
-                    // player view-button changes are both ignored here.
-                    if (oroad.get_view_mode() != announcement_hold_view)
-                        oroad.set_view_mode(announcement_hold_view, true);
-
-                    draw_showcase_text();
-
-                    if (tick_due(phase_due_tick))
-                        apply_announced_view();
-                }
-                else
-                {
-                    // During the six-second demonstration the announced view
-                    // owns the camera. All VIEW1/2/3/VIEWPOINT input is ignored.
-                    if (oroad.get_view_mode() != phase_view)
-                        oroad.set_view_mode(phase_view, true);
-
-                    draw_showcase_text();
-
-                    if (tick_due(phase_due_tick))
-                    {
-                        if (showcase_phase < 2)
-                            begin_view_phase(showcase_phase + 1);
-                        else
-                            finish_showcase();
-                    }
+                    if (showcase_phase < 2)
+                        begin_view_phase(showcase_phase + 1);
+                    else
+                        finish_showcase();
                 }
             }
         }

--- a/src/main/engine/external_output_settings.hpp
+++ b/src/main/engine/external_output_settings.hpp
@@ -7,6 +7,7 @@
 #include "main.hpp"
 #include "roms.hpp"
 #include "video.hpp"
+#include "engine/external_outputs.hpp"
 #include "engine/ohud.hpp"
 #include "engine/oroad.hpp"
 #include "engine/outrun.hpp"
@@ -60,8 +61,9 @@ inline ExternalOutputSettings& external_output_settings()
 }
 
 // Enhanced-attract showcase wrapper. The normal Enhanced Attract drive is
-// reused directly: after High Scores / Logo the car continues from the same
-// road position and the three camera views are presented on that live scene.
+// reused directly: no demo level, speed override, traffic override or road
+// reset is used. The showcase only changes the camera and briefly pauses the
+// engine while introducing each view.
 class ExternalOutputsWithAttractShowcase : public ExternalOutputs
 {
 public:
@@ -138,11 +140,22 @@ private:
 
     static constexpr std::chrono::milliseconds FREEZE_TIME{900};
     static constexpr std::chrono::seconds DRIVE_TIME{7};
+    static constexpr std::chrono::seconds INITIAL_SHOWCASE_DELAY{30};
+    static constexpr std::chrono::milliseconds POST_LOGO_SHOWCASE_DELAY{4500};
 
-    bool showcase_pending = false;
     bool showcase_active = false;
     bool showcase_freezing = false;
     bool manual_override = false;
+
+    // Scheduling: the first presentation happens about 30 seconds after the
+    // initial Enhanced Attract drive begins. Later presentations are armed by
+    // Logo -> Attract and begin 4.5 seconds after the resumed drive starts.
+    bool initial_attract_seen = false;
+    bool first_showcase_started = false;
+    bool delayed_showcase_pending = false;
+    bool post_logo_resume_pending = false;
+    Clock::time_point showcase_due{};
+
     bool view1_old = false;
     bool view2_old = false;
     bool view3_old = false;
@@ -257,9 +270,9 @@ private:
         phase_time = Clock::now();
         phase_start_frame = cannonball::frame;
 
-        // Switch the camera while the live road is still at the exact frame we
-        // just displayed. One road pass applies the new horizon immediately;
-        // the following short engine pause then holds that transformed scene.
+        // The car keeps the exact speed/input state produced by Enhanced Attract.
+        // We only switch the camera. A road pass re-renders the same road position
+        // with the new snapped horizon before the short presentation freeze.
         oroad.set_view_mode(phase_view, true);
         oroad.tick();
         pause_engine = true;
@@ -267,7 +280,8 @@ private:
 
     void start_showcase()
     {
-        showcase_pending = false;
+        delayed_showcase_pending = false;
+        first_showcase_started = true;
         showcase_active = true;
         attract_cycle_state = outrun.capture_attract_runtime_state();
         attract_cycle_saved = true;
@@ -280,9 +294,8 @@ private:
         pause_engine = false;
         showcase_freezing = false;
 
-        // The normal Enhanced Attract view timer has continued in the background
-        // during the moving sections. Re-sync it to the camera we actually end
-        // on, so its next automatic change starts a fresh, predictable cycle.
+        // Re-sync the normal automatic view timer to the view on screen so the
+        // next automatic attract change starts a fresh, predictable cycle.
         if (attract_cycle_saved)
         {
             attract_cycle_state.view = oroad.get_view_mode();
@@ -301,31 +314,69 @@ private:
     {
         pause_engine = false;
         showcase_active = false;
-        showcase_pending = false;
         showcase_freezing = false;
         showcase_phase = -1;
         manual_override = false;
         attract_cycle_saved = false;
     }
 
+    void reset_schedule()
+    {
+        initial_attract_seen = false;
+        first_showcase_started = false;
+        delayed_showcase_pending = false;
+        post_logo_resume_pending = false;
+        showcase_due = Clock::time_point{};
+    }
+
     void update_showcase()
     {
+        const Clock::time_point now = Clock::now();
         const bool enhanced_game =
             cannonball::state == cannonball::STATE_GAME &&
             config.engine.new_attract;
 
-        // Logo timeout changes GS_LOGO -> GS_INIT for one frame. Remember that
-        // edge, then start only once GS_INIT has resumed the real attract drive.
+        // If Enhanced Attract is disabled, the next activation gets a fresh
+        // first-run schedule instead of inheriting an old pending timer.
+        if (!config.engine.new_attract)
+            reset_schedule();
+
+        // First run: start counting when the initial real attract drive begins.
+        // This deliberately does not depend on the High Score / Logo cycle.
         if (enhanced_game &&
+            outrun.game_state == GS_ATTRACT &&
+            !initial_attract_seen)
+        {
+            initial_attract_seen = true;
+            delayed_showcase_pending = true;
+            showcase_due = now + INITIAL_SHOWCASE_DELAY;
+        }
+
+        // Subsequent runs: Logo times out to GS_INIT for one frame. Arm the
+        // delayed presentation here, but start its 4.5-second timer only once
+        // the normal Enhanced Attract drive has actually resumed.
+        if (enhanced_game &&
+            first_showcase_started &&
             previous_game_state == GS_LOGO &&
             outrun.game_state == GS_INIT)
         {
-            showcase_pending = true;
+            post_logo_resume_pending = true;
         }
 
-        if (showcase_pending &&
-            enhanced_game &&
+        if (enhanced_game &&
+            post_logo_resume_pending &&
             outrun.game_state == GS_ATTRACT)
+        {
+            post_logo_resume_pending = false;
+            delayed_showcase_pending = true;
+            showcase_due = now + POST_LOGO_SHOWCASE_DELAY;
+        }
+
+        if (!showcase_active &&
+            delayed_showcase_pending &&
+            enhanced_game &&
+            outrun.game_state == GS_ATTRACT &&
+            now >= showcase_due)
         {
             start_showcase();
         }
@@ -336,50 +387,45 @@ private:
             {
                 abort_showcase();
             }
+            else if (showcase_freezing)
+            {
+                // Ignore manual VR changes during the explanatory freeze;
+                // the announced view owns this short presentation moment.
+                manual_view_pressed();
+                if (oroad.get_view_mode() != phase_view)
+                {
+                    oroad.set_view_mode(phase_view, true);
+                    oroad.tick();
+                }
+
+                draw_showcase_text();
+
+                if (now - phase_time >= FREEZE_TIME)
+                {
+                    showcase_freezing = false;
+                    pause_engine = false;
+                    phase_time = now;
+                }
+            }
             else
             {
-                const Clock::time_point now = Clock::now();
+                if (manual_view_pressed())
+                    manual_override = true;
 
-                if (showcase_freezing)
+                // The existing Enhanced Attract timer may try to change the
+                // view underneath the presentation. Hold the announced view
+                // unless the player deliberately used a VR button.
+                if (!manual_override && oroad.get_view_mode() != phase_view)
+                    oroad.set_view_mode(phase_view, true);
+
+                draw_showcase_text();
+
+                if (now - phase_time >= DRIVE_TIME)
                 {
-                    // Ignore manual VR changes during the explanatory freeze;
-                    // the announced view owns this short presentation moment.
-                    manual_view_pressed();
-                    if (oroad.get_view_mode() != phase_view)
-                    {
-                        oroad.set_view_mode(phase_view, true);
-                        oroad.tick();
-                    }
-
-                    draw_showcase_text();
-
-                    if (now - phase_time >= FREEZE_TIME)
-                    {
-                        showcase_freezing = false;
-                        pause_engine = false;
-                        phase_time = now;
-                    }
-                }
-                else
-                {
-                    if (manual_view_pressed())
-                        manual_override = true;
-
-                    // The existing Enhanced Attract timer may try to change the
-                    // view underneath the presentation. Hold the announced view
-                    // unless the player deliberately used a VR button.
-                    if (!manual_override && oroad.get_view_mode() != phase_view)
-                        oroad.set_view_mode(phase_view, true);
-
-                    draw_showcase_text();
-
-                    if (now - phase_time >= DRIVE_TIME)
-                    {
-                        if (showcase_phase < 2)
-                            begin_view_phase(showcase_phase + 1);
-                        else
-                            finish_showcase();
-                    }
+                    if (showcase_phase < 2)
+                        begin_view_phase(showcase_phase + 1);
+                    else
+                        finish_showcase();
                 }
             }
         }

--- a/src/main/engine/external_output_settings.hpp
+++ b/src/main/engine/external_output_settings.hpp
@@ -10,6 +10,7 @@
 #include "engine/external_outputs.hpp"
 #include "engine/ohud.hpp"
 #include "engine/oroad.hpp"
+#include "engine/ostats.hpp"
 #include "engine/outrun.hpp"
 #include "frontend/config.hpp"
 #include "frontend/xml_parser.h"
@@ -140,21 +141,28 @@ private:
 
     static constexpr std::chrono::milliseconds FREEZE_TIME{900};
     static constexpr std::chrono::seconds DRIVE_TIME{7};
-    static constexpr std::chrono::seconds INITIAL_SHOWCASE_DELAY{30};
-    static constexpr std::chrono::milliseconds POST_LOGO_SHOWCASE_DELAY{4500};
+
+    // Enhanced Attract starts each driving section at BCD 0x80 (80 seconds).
+    // Trigger the in-section presentation at the real halfway point: 40 seconds
+    // remaining. Using the game timer means menu visits automatically pause it.
+    static constexpr uint8_t ATTRACT_MIDPOINT_BCD = 0x40;
+
+    // After a Logo screen we also introduce the views shortly after the real
+    // attract drive resumes. tick_counter runs at the engine's 30 Hz logic rate
+    // and stops while the game is in the menu or our short presentation freeze.
+    static constexpr uint32_t POST_LOGO_DELAY_TICKS = 135; // 4.5 seconds at 30 Hz.
 
     bool showcase_active = false;
     bool showcase_freezing = false;
     bool manual_override = false;
 
-    // Scheduling: the first presentation happens about 30 seconds after the
-    // initial Enhanced Attract drive begins. Later presentations are armed by
-    // Logo -> Attract and begin 4.5 seconds after the resumed drive starts.
-    bool initial_attract_seen = false;
-    bool first_showcase_started = false;
-    bool delayed_showcase_pending = false;
+    // Every real GS_ATTRACT driving section gets one midpoint showcase. After a
+    // Logo -> Attract transition it additionally gets one early showcase after
+    // 4.5 seconds. These flags describe the current driving section only.
+    bool midpoint_showcase_pending = false;
     bool post_logo_resume_pending = false;
-    Clock::time_point showcase_due{};
+    bool post_logo_showcase_pending = false;
+    uint32_t post_logo_due_tick = 0;
 
     bool view1_old = false;
     bool view2_old = false;
@@ -271,8 +279,9 @@ private:
         phase_start_frame = cannonball::frame;
 
         // Preserve the exact native Enhanced Attract vehicle state. We never
-        // write car_increment, accelerator, brake or steering here. The road
-        // pass only rebuilds the same road position with the snapped camera.
+        // write car_increment, accelerator, brake or steering here. This road
+        // pass only rebuilds the same road position with the snapped camera so
+        // the new view is already visible during the explanatory freeze.
         oroad.set_view_mode(phase_view, true);
         oroad.tick();
         pause_engine = true;
@@ -280,8 +289,6 @@ private:
 
     void start_showcase()
     {
-        delayed_showcase_pending = false;
-        first_showcase_started = true;
         showcase_active = true;
         attract_cycle_state = outrun.capture_attract_runtime_state();
         attract_cycle_saved = true;
@@ -320,13 +327,9 @@ private:
         attract_cycle_saved = false;
     }
 
-    void reset_schedule()
+    bool post_logo_delay_elapsed() const
     {
-        initial_attract_seen = false;
-        first_showcase_started = false;
-        delayed_showcase_pending = false;
-        post_logo_resume_pending = false;
-        showcase_due = Clock::time_point{};
+        return static_cast<int32_t>(outrun.tick_counter - post_logo_due_tick) >= 0;
     }
 
     void update_showcase()
@@ -336,49 +339,60 @@ private:
             cannonball::state == cannonball::STATE_GAME &&
             config.engine.new_attract;
 
-        // If Enhanced Attract is disabled, the next activation gets a fresh
-        // first-run schedule instead of inheriting an old pending timer.
-        if (!config.engine.new_attract)
-            reset_schedule();
-
-        // First run: start counting when the initial real attract drive begins.
-        // This deliberately does not depend on the High Score / Logo cycle.
+        // Logo timeout changes GS_LOGO -> GS_INIT for one frame. Remember this
+        // edge so the resumed driving section also gets its early presentation.
         if (enhanced_game &&
-            outrun.game_state == GS_ATTRACT &&
-            !initial_attract_seen)
-        {
-            initial_attract_seen = true;
-            delayed_showcase_pending = true;
-            showcase_due = now + INITIAL_SHOWCASE_DELAY;
-        }
-
-        // Subsequent runs: Logo times out to GS_INIT for one frame. Arm the
-        // delayed presentation here, but start its 4.5-second timer only once
-        // the normal Enhanced Attract drive has actually resumed.
-        if (enhanced_game &&
-            first_showcase_started &&
             previous_game_state == GS_LOGO &&
             outrun.game_state == GS_INIT)
         {
             post_logo_resume_pending = true;
         }
 
+        // A transition into GS_ATTRACT means a new real driving section has
+        // begun. Arm one midpoint presentation every time, including the first
+        // attract after boot/game start. Menu visits do not create this edge,
+        // because the underlying game_state remains GS_ATTRACT while in menu.
         if (enhanced_game &&
-            post_logo_resume_pending &&
-            outrun.game_state == GS_ATTRACT)
+            outrun.game_state == GS_ATTRACT &&
+            previous_game_state != GS_ATTRACT)
         {
-            post_logo_resume_pending = false;
-            delayed_showcase_pending = true;
-            showcase_due = now + POST_LOGO_SHOWCASE_DELAY;
+            midpoint_showcase_pending = true;
+
+            if (post_logo_resume_pending)
+            {
+                post_logo_resume_pending = false;
+                post_logo_showcase_pending = true;
+                post_logo_due_tick = outrun.tick_counter + POST_LOGO_DELAY_TICKS;
+            }
         }
 
-        if (!showcase_active &&
-            delayed_showcase_pending &&
-            enhanced_game &&
-            outrun.game_state == GS_ATTRACT &&
-            now >= showcase_due)
+        // If Enhanced Attract itself is turned off, discard presentation work.
+        // Do not do this merely because the menu is open: that is exactly what
+        // lets the real attract timer survive a menu round-trip.
+        if (!config.engine.new_attract)
         {
-            start_showcase();
+            midpoint_showcase_pending = false;
+            post_logo_resume_pending = false;
+            post_logo_showcase_pending = false;
+        }
+
+        if (!showcase_active && enhanced_game && outrun.game_state == GS_ATTRACT)
+        {
+            // Shortly after every Logo, show the early presentation first.
+            if (post_logo_showcase_pending && post_logo_delay_elapsed())
+            {
+                post_logo_showcase_pending = false;
+                start_showcase();
+            }
+            // Then show exactly one more presentation at the genuine halfway
+            // point of this 80-second driving section. Because time_counter is
+            // the engine timer, menu time and our freezes do not advance it.
+            else if (midpoint_showcase_pending &&
+                     ostats.time_counter <= ATTRACT_MIDPOINT_BCD)
+            {
+                midpoint_showcase_pending = false;
+                start_showcase();
+            }
         }
 
         if (showcase_active)

--- a/src/main/engine/external_output_settings.hpp
+++ b/src/main/engine/external_output_settings.hpp
@@ -1,7 +1,19 @@
 #pragma once
 
+#include <cstring>
 #include <string>
 
+#include "main.hpp"
+#include "roms.hpp"
+#include "trackloader.hpp"
+#include "video.hpp"
+#include "engine/oferrari.hpp"
+#include "engine/ohud.hpp"
+#include "engine/oinitengine.hpp"
+#include "engine/oinputs.hpp"
+#include "engine/oroad.hpp"
+#include "engine/osprites.hpp"
+#include "engine/otraffic.hpp"
 #include "frontend/config.hpp"
 #include "frontend/xml_parser.h"
 
@@ -45,3 +57,317 @@ inline ExternalOutputSettings& external_output_settings()
     settings.load_once();
     return settings;
 }
+
+// Enhanced-attract showcase wrapper. external_outputs.hpp is included before
+// this header, so deriving here lets the existing OOutputs call site remain
+// untouched while the showcase can override the final lamp values.
+class ExternalOutputsWithAttractShowcase : public ExternalOutputs
+{
+public:
+    void update(bool enable_network,
+                bool enable_windows,
+                int port,
+                bool application_running,
+                int start_lamp,
+                int brake_lamp,
+                int view_lamp,
+                int view1_lamp,
+                int view2_lamp,
+                int view3_lamp)
+    {
+        update_showcase();
+
+        if (showcase_active)
+        {
+            // The dedicated VR lamps own the presentation during the showcase.
+            view_lamp = 0;
+            view1_lamp = 0;
+            view2_lamp = 0;
+            view3_lamp = 0;
+
+            const bool fast_blink = (outrun.tick_counter & BIT_3) != 0;
+            const uint8_t view = oroad.get_view_mode();
+
+            if (view == ORoad::VIEW_ORIGINAL)
+            {
+                if (manual_override)
+                {
+                    view1_lamp = fast_blink ? 1 : 0;
+                }
+                else
+                {
+                    // Automatic ORIGINAL uses the same fast ping-pong chase as
+                    // the enhanced attract mode: 1 -> 2 -> 3 -> 2 -> ...
+                    const uint8_t chase =
+                        static_cast<uint8_t>(((outrun.tick_counter - phase_start_tick) >> 3) & 3);
+                    view1_lamp = chase == 0 ? 1 : 0;
+                    view2_lamp = (chase == 1 || chase == 3) ? 1 : 0;
+                    view3_lamp = chase == 2 ? 1 : 0;
+                }
+            }
+            else if (view == ORoad::VIEW_ELEVATED)
+            {
+                view2_lamp = fast_blink ? 1 : 0;
+            }
+            else if (view == ORoad::VIEW_INCAR)
+            {
+                view3_lamp = fast_blink ? 1 : 0;
+            }
+        }
+
+        ExternalOutputs::update(
+            enable_network,
+            enable_windows,
+            port,
+            application_running,
+            start_lamp,
+            brake_lamp,
+            view_lamp,
+            view1_lamp,
+            view2_lamp,
+            view3_lamp);
+    }
+
+private:
+    static const uint32_t VIEW_TIME = 120; // 4 seconds at the 30 Hz game tick.
+    static const uint32_t TOTAL_TIME = VIEW_TIME * 3;
+
+    bool showcase_pending = false;
+    bool showcase_active = false;
+    bool manual_override = false;
+    int previous_game_state = -1;
+    int showcase_phase = -1;
+    uint8_t phase_view = ORoad::VIEW_ORIGINAL;
+    uint32_t showcase_start_tick = 0;
+    uint32_t phase_start_tick = 0;
+
+    void clear_double_row(uint8_t y)
+    {
+        for (int x = 0; x < 40; x++)
+        {
+            video.write_text16(ohud.translate(x, y), 0);
+            video.write_text16(ohud.translate(x, y) + 0x80, 0);
+        }
+    }
+
+    void draw_double_row_centered(uint8_t y, const char* text, uint16_t pal)
+    {
+        int length = static_cast<int>(std::strlen(text));
+        if (length > 40)
+            length = 40;
+
+        const int x_start = 20 - (length / 2);
+        clear_double_row(y);
+
+        uint32_t dst_addr = ohud.translate(x_start, y);
+
+        for (int i = 0; i < length; i++)
+        {
+            uint16_t c = static_cast<uint8_t>(text[i]);
+
+            if (c >= 'a' && c <= 'z')
+                c -= 0x20;
+
+            if (c == ' ')
+            {
+                video.write_text16(&dst_addr, 0);
+                video.write_text16(0x7E + dst_addr, 0);
+            }
+            else if (c >= 'A' && c <= 'Z')
+            {
+                c = ((c - 'A') * 2) + pal;
+                video.write_text16(&dst_addr, c);
+                video.write_text16(0x7E + dst_addr, c + 1);
+            }
+        }
+    }
+
+    void draw_showcase_text()
+    {
+        // Extract the exact palette used by the original SELECT MUSIC prompt.
+        uint32_t select_music_style = TEXT2_SELECT_MUSIC + 2;
+        uint16_t prompt_pal = roms.rom0.read8(&select_music_style);
+        prompt_pal = 0x80A0 | ((prompt_pal << 9) | ((prompt_pal >> 7) & 1));
+
+        draw_double_row_centered(2, "TRY THREE DIFFERENT VIEWS", prompt_pal);
+        draw_double_row_centered(4, "WITH THE VR BUTTONS!", prompt_pal);
+
+        const char* view_name = "ORIGINAL VIEW";
+        const uint8_t view = oroad.get_view_mode();
+        if (view == ORoad::VIEW_ELEVATED)
+            view_name = "ELEVATED VIEW";
+        else if (view == ORoad::VIEW_INCAR)
+            view_name = "IN-CAR VIEW";
+
+        // Same yellow/black double-row style as the enhanced Music Select song
+        // title. The selected view deliberately blinks like an arcade prompt.
+        if (outrun.tick_counter & BIT_4)
+            draw_double_row_centered(7, view_name, 0x8AA0);
+        else
+            clear_double_row(7);
+    }
+
+    void hide_non_palm_opening_scenery()
+    {
+        // Stage 1's palm trees use the normal level-object routine. Hide the
+        // special start-line/water/grass/cloud routines so the short showcase
+        // reads as road + palms rather than a normal attract-stage scene.
+        // Limit this to the stage-1 level-object slots; Ferrari/passenger/smoke
+        // slots live outside this range and remain untouched.
+        for (int i = 0; i <= 0x44; i++)
+        {
+            oentry* sprite = &osprites.jump_table[i];
+            if ((sprite->control & OSprites::ENABLE) && sprite->function_holder != 0)
+                sprite->control &= ~OSprites::ENABLE;
+        }
+    }
+
+    void reset_showcase_segment(uint8_t view)
+    {
+        // Reuse the first few seconds of Coconut Beach for every camera. This
+        // keeps all three comparisons on the same straight road section and
+        // avoids ever reaching the first bend during the 12-second showcase.
+        oroad.init();
+        oinitengine.init(0);
+
+        oferrari.car_ctrl_active = true;
+        oinitengine.car_x_pos = 0;
+        oinitengine.car_x_old = 0;
+        oroad.car_x_bak = 0;
+
+        // Start at full normal OutRun speed instead of accelerating from rest.
+        oinitengine.car_increment = 0xFA << 16;
+        oferrari.car_inc_old = 0xFA;
+        oinputs.acc_adjust = 0xFF;
+        oinputs.brake_adjust = 0;
+        oinputs.steering_adjust = 0;
+
+        // Present a normal single road immediately, without the wide start-grid
+        // road geometry, and suppress every traffic slot/spawn during the demo.
+        oroad.road_width = 0xD4 << 16;
+        oroad.road_width_bak = 0xD4;
+        otraffic.disable_traffic();
+        otraffic.set_custom_max_traffic(0);
+        otraffic.ai_traffic = 0;
+
+        // Remove any hard-coded start-line objects left in the reusable slots.
+        for (int i = 0; i <= 0x44; i++)
+            osprites.jump_table[i].control &= ~OSprites::ENABLE;
+
+        oroad.set_view_mode(view, true);
+        phase_view = view;
+        manual_override = false;
+        phase_start_tick = outrun.tick_counter;
+    }
+
+    void start_showcase()
+    {
+        showcase_pending = false;
+        showcase_active = true;
+        showcase_phase = 0;
+        showcase_start_tick = outrun.tick_counter;
+        video.clear_text_ram();
+        reset_showcase_segment(ORoad::VIEW_ORIGINAL);
+    }
+
+    void end_showcase()
+    {
+        showcase_active = false;
+        showcase_phase = -1;
+        manual_override = false;
+        video.clear_text_ram();
+        oroad.set_view_mode(ORoad::VIEW_ORIGINAL, true);
+        otraffic.set_max_traffic();
+
+        // GS_INIT restarts the existing enhanced attract timer/view sequence on
+        // the next engine tick. No normal attract behaviour is replaced.
+        outrun.game_state = GS_INIT;
+    }
+
+    void update_showcase()
+    {
+        const bool enhanced_game =
+            cannonball::state == cannonball::STATE_GAME &&
+            config.engine.new_attract;
+
+        // Logo timeout changes GS_LOGO -> GS_INIT for one frame. Remember that
+        // edge, then start only when GS_INIT has entered GS_ATTRACT next tick.
+        if (enhanced_game &&
+            previous_game_state == GS_LOGO &&
+            outrun.game_state == GS_INIT)
+        {
+            showcase_pending = true;
+        }
+
+        if (showcase_pending &&
+            enhanced_game &&
+            outrun.game_state == GS_ATTRACT)
+        {
+            start_showcase();
+        }
+
+        if (showcase_active)
+        {
+            if (!enhanced_game || outrun.game_state != GS_ATTRACT)
+            {
+                showcase_active = false;
+                showcase_pending = false;
+                showcase_phase = -1;
+                manual_override = false;
+                otraffic.set_max_traffic();
+            }
+            else
+            {
+                const uint32_t elapsed = outrun.tick_counter - showcase_start_tick;
+
+                if (elapsed >= TOTAL_TIME)
+                {
+                    end_showcase();
+                }
+                else
+                {
+                    const int phase = static_cast<int>(elapsed / VIEW_TIME);
+                    static const uint8_t VIEWS[] =
+                    {
+                        ORoad::VIEW_ORIGINAL,
+                        ORoad::VIEW_ELEVATED,
+                        ORoad::VIEW_INCAR,
+                    };
+
+                    if (phase != showcase_phase)
+                    {
+                        showcase_phase = phase;
+                        reset_showcase_segment(VIEWS[phase]);
+                    }
+                    else if (oroad.get_view_mode() != phase_view)
+                    {
+                        // OOutputs already processed the cabinet/player VR
+                        // button before this wrapper runs, so a mismatch here is
+                        // a real manual override. Keep it until the next phase.
+                        manual_override = true;
+                    }
+
+                    // Keep the demonstration pinned to full speed and centreline
+                    // regardless of normal AI braking/collision decisions.
+                    oinitengine.car_increment = 0xFA << 16;
+                    oferrari.car_inc_old = 0xFA;
+                    oinitengine.car_x_pos = 0;
+                    oinputs.acc_adjust = 0xFF;
+                    oinputs.brake_adjust = 0;
+                    oinputs.steering_adjust = 0;
+                    otraffic.disable_traffic();
+                    otraffic.set_custom_max_traffic(0);
+                    otraffic.ai_traffic = 0;
+                    hide_non_palm_opening_scenery();
+                    draw_showcase_text();
+                }
+            }
+        }
+
+        previous_game_state = outrun.game_state;
+    }
+};
+
+// ooutputs.cpp declares its transport object after this header is included.
+// Use the showcase-aware subclass without touching the existing output wrapper.
+#define ExternalOutputs ExternalOutputsWithAttractShowcase

--- a/src/main/engine/external_output_settings.hpp
+++ b/src/main/engine/external_output_settings.hpp
@@ -233,24 +233,12 @@ private:
             clear_double_row(7);
     }
 
-    bool manual_view_pressed()
+    void sync_view_button_states()
     {
-        const bool view1 = input.is_pressed(Input::VIEW1);
-        const bool view2 = input.is_pressed(Input::VIEW2);
-        const bool view3 = input.is_pressed(Input::VIEW3);
-        const bool viewpoint = input.is_pressed(Input::VIEWPOINT);
-
-        const bool pressed =
-            (view1 && !view1_old) ||
-            (view2 && !view2_old) ||
-            (view3 && !view3_old) ||
-            (viewpoint && !viewpoint_old);
-
-        view1_old = view1;
-        view2_old = view2;
-        view3_old = view3;
-        viewpoint_old = viewpoint;
-        return pressed;
+        view1_old = input.is_pressed(Input::VIEW1);
+        view2_old = input.is_pressed(Input::VIEW2);
+        view3_old = input.is_pressed(Input::VIEW3);
+        viewpoint_old = input.is_pressed(Input::VIEWPOINT);
     }
 
     void reset_view_on_start()
@@ -416,10 +404,10 @@ private:
             }
             else
             {
-                // Consume all view-button edges while the presentation owns the
-                // camera. This keeps held buttons from becoming a fresh input as
-                // soon as the showcase ends, but no view input is acted upon.
-                manual_view_pressed();
+                // Consume all view-button states while the presentation owns
+                // the camera. This prevents a held button from becoming a fresh
+                // input as soon as the showcase ends.
+                sync_view_button_states();
 
                 if (showcase_announcing)
                 {
@@ -457,7 +445,7 @@ private:
         {
             // Keep edge trackers current outside the showcase so a held VR
             // button cannot become a false new press at the next presentation.
-            manual_view_pressed();
+            sync_view_button_states();
         }
 
         previous_game_state = outrun.game_state;

--- a/src/main/engine/external_output_settings.hpp
+++ b/src/main/engine/external_output_settings.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <chrono>
 #include <cstring>
 #include <string>
 
@@ -15,10 +14,6 @@
 #include "frontend/config.hpp"
 #include "frontend/xml_parser.h"
 #include "sdl2/input.hpp"
-
-// Main engine pause flag. The showcase owns this only for its short camera
-// presentation freezes; audio and rendering continue normally.
-extern bool pause_engine;
 
 // Optional external-output transport settings. SmartyPi remains independent.
 struct ExternalOutputSettings
@@ -62,9 +57,9 @@ inline ExternalOutputSettings& external_output_settings()
 }
 
 // Enhanced-attract showcase wrapper. The normal Enhanced Attract drive is
-// reused directly: no demo level, speed override, traffic override or road
-// reset is used. The showcase only changes the camera and briefly pauses the
-// engine while introducing each view.
+// reused directly: no demo level, speed override, traffic override, road reset
+// or engine pause is used. Each camera is announced first, then applied while
+// the live attract drive continues uninterrupted.
 class ExternalOutputsWithAttractShowcase : public ExternalOutputs
 {
 public:
@@ -88,7 +83,8 @@ public:
 
         if (showcase_active)
         {
-            // The dedicated VR lamps own the presentation during the showcase.
+            // The dedicated VR lamps always follow the camera that is actually
+            // on screen, including during the two-second announcement period.
             view_lamp = 0;
             view1_lamp = 0;
             view2_lamp = 0;
@@ -137,23 +133,23 @@ public:
     }
 
 private:
-    using Clock = std::chrono::steady_clock;
-
-    static constexpr std::chrono::milliseconds FREEZE_TIME{900};
-    static constexpr std::chrono::seconds DRIVE_TIME{7};
+    // Each view is announced for two seconds while the previous live camera
+    // continues to drive, then demonstrated for six seconds after the switch.
+    static constexpr uint32_t ANNOUNCE_TIME_TICKS = 60; // 2 seconds at 30 Hz.
+    static constexpr uint32_t VIEW_TIME_TICKS = 180;    // 6 seconds at 30 Hz.
 
     // Enhanced Attract starts each driving section at BCD 0x80 (80 seconds).
     // Trigger the in-section presentation at the real halfway point: 40 seconds
     // remaining. Using the game timer means menu visits automatically pause it.
     static constexpr uint8_t ATTRACT_MIDPOINT_BCD = 0x40;
 
-    // After a Logo screen we also introduce the views shortly after the real
-    // attract drive resumes. tick_counter runs at the engine's 30 Hz logic rate
-    // and stops while the game is in the menu or our short presentation freeze.
+    // After a Logo screen we additionally introduce the views shortly after the
+    // normal attract drive resumes. tick_counter follows the 30 Hz engine logic
+    // and therefore does not advance while the game is in the menu.
     static constexpr uint32_t POST_LOGO_DELAY_TICKS = 135; // 4.5 seconds at 30 Hz.
 
     bool showcase_active = false;
-    bool showcase_freezing = false;
+    bool showcase_announcing = false;
     bool manual_override = false;
 
     // Every real GS_ATTRACT driving section gets one midpoint showcase. After a
@@ -171,8 +167,9 @@ private:
     int previous_game_state = -1;
     int showcase_phase = -1;
     uint8_t phase_view = ORoad::VIEW_ORIGINAL;
+    uint8_t announcement_hold_view = ORoad::VIEW_ORIGINAL;
     uint32_t phase_start_frame = 0;
-    Clock::time_point phase_time{};
+    uint32_t phase_due_tick = 0;
     Outrun::AttractRuntimeState attract_cycle_state{};
     bool attract_cycle_saved = false;
 
@@ -217,6 +214,15 @@ private:
         }
     }
 
+    const char* phase_view_name() const
+    {
+        if (phase_view == ORoad::VIEW_ELEVATED)
+            return "ELEVATED VIEW";
+        if (phase_view == ORoad::VIEW_INCAR)
+            return "IN CAR VIEW";
+        return "ORIGINAL VIEW";
+    }
+
     void draw_showcase_text()
     {
         // Extract the exact palette used by the original SELECT MUSIC prompt.
@@ -227,17 +233,11 @@ private:
         draw_double_row_centered(2, "TRY THREE DIFFERENT VIEWS", prompt_pal);
         draw_double_row_centered(4, "WITH THE VR BUTTONS!", prompt_pal);
 
-        const char* view_name = "ORIGINAL VIEW";
-        const uint8_t view = oroad.get_view_mode();
-        if (view == ORoad::VIEW_ELEVATED)
-            view_name = "ELEVATED VIEW";
-        else if (view == ORoad::VIEW_INCAR)
-            view_name = "IN CAR VIEW";
-
-        // Keep the name solid during the short freeze so the changed camera is
-        // clearly explained. Once driving resumes it returns to the arcade blink.
-        if (showcase_freezing || (cannonball::frame & 0x10))
-            draw_double_row_centered(7, view_name, 0x8AA0);
+        // During the two-second lead-in the upcoming view name is held solid so
+        // the player reads the explanation before the camera actually changes.
+        // Once the view is active, the name returns to the arcade-style blink.
+        if (showcase_announcing || (cannonball::frame & 0x10))
+            draw_double_row_centered(7, phase_view_name(), 0x8AA0);
         else
             clear_double_row(7);
     }
@@ -262,6 +262,11 @@ private:
         return pressed;
     }
 
+    bool tick_due(uint32_t due) const
+    {
+        return static_cast<int32_t>(outrun.tick_counter - due) >= 0;
+    }
+
     void begin_view_phase(int phase)
     {
         static const uint8_t VIEWS[] =
@@ -273,18 +278,23 @@ private:
 
         showcase_phase = phase;
         phase_view = VIEWS[phase];
+        announcement_hold_view = oroad.get_view_mode();
         manual_override = false;
-        showcase_freezing = true;
-        phase_time = Clock::now();
+        showcase_announcing = true;
         phase_start_frame = cannonball::frame;
+        phase_due_tick = outrun.tick_counter + ANNOUNCE_TIME_TICKS;
+    }
 
-        // Preserve the exact native Enhanced Attract vehicle state. We never
-        // write car_increment, accelerator, brake or steering here. This road
-        // pass only rebuilds the same road position with the snapped camera so
-        // the new view is already visible during the explanatory freeze.
+    void apply_announced_view()
+    {
+        showcase_announcing = false;
+        manual_override = false;
+
+        // Camera change only. Vehicle speed, AI, traffic, road position and all
+        // other Enhanced Attract logic continue exactly as they normally would.
         oroad.set_view_mode(phase_view, true);
-        oroad.tick();
-        pause_engine = true;
+        phase_start_frame = cannonball::frame;
+        phase_due_tick = outrun.tick_counter + VIEW_TIME_TICKS;
     }
 
     void start_showcase()
@@ -298,8 +308,7 @@ private:
 
     void finish_showcase()
     {
-        pause_engine = false;
-        showcase_freezing = false;
+        showcase_announcing = false;
 
         // Re-sync the normal automatic view timer to the view on screen so the
         // next automatic attract change starts a fresh, predictable cycle.
@@ -319,9 +328,8 @@ private:
 
     void abort_showcase()
     {
-        pause_engine = false;
         showcase_active = false;
-        showcase_freezing = false;
+        showcase_announcing = false;
         showcase_phase = -1;
         manual_override = false;
         attract_cycle_saved = false;
@@ -329,12 +337,11 @@ private:
 
     bool post_logo_delay_elapsed() const
     {
-        return static_cast<int32_t>(outrun.tick_counter - post_logo_due_tick) >= 0;
+        return tick_due(post_logo_due_tick);
     }
 
     void update_showcase()
     {
-        const Clock::time_point now = Clock::now();
         const bool enhanced_game =
             cannonball::state == cannonball::STATE_GAME &&
             config.engine.new_attract;
@@ -386,7 +393,7 @@ private:
             }
             // Then show exactly one more presentation at the genuine halfway
             // point of this 80-second driving section. Because time_counter is
-            // the engine timer, menu time and our freezes do not advance it.
+            // the engine timer, menu time does not advance it.
             else if (midpoint_showcase_pending &&
                      ostats.time_counter <= ATTRACT_MIDPOINT_BCD)
             {
@@ -401,45 +408,40 @@ private:
             {
                 abort_showcase();
             }
-            else if (showcase_freezing)
-            {
-                // Ignore manual VR changes during the explanatory freeze;
-                // the announced view owns this short presentation moment.
-                manual_view_pressed();
-                if (oroad.get_view_mode() != phase_view)
-                {
-                    oroad.set_view_mode(phase_view, true);
-                    oroad.tick();
-                }
-
-                draw_showcase_text();
-
-                if (now - phase_time >= FREEZE_TIME)
-                {
-                    showcase_freezing = false;
-                    pause_engine = false;
-                    phase_time = now;
-                }
-            }
             else
             {
                 if (manual_view_pressed())
                     manual_override = true;
 
-                // The existing Enhanced Attract timer may try to change the
-                // view underneath the presentation. Hold the announced view
-                // unless the player deliberately used a VR button.
-                if (!manual_override && oroad.get_view_mode() != phase_view)
-                    oroad.set_view_mode(phase_view, true);
-
-                draw_showcase_text();
-
-                if (now - phase_time >= DRIVE_TIME)
+                if (showcase_announcing)
                 {
-                    if (showcase_phase < 2)
-                        begin_view_phase(showcase_phase + 1);
-                    else
-                        finish_showcase();
+                    // Keep the live view stable against the normal automatic
+                    // Enhanced Attract view timer while the next view is being
+                    // announced. A real VR-button press is still respected.
+                    if (!manual_override && oroad.get_view_mode() != announcement_hold_view)
+                        oroad.set_view_mode(announcement_hold_view, true);
+
+                    draw_showcase_text();
+
+                    if (tick_due(phase_due_tick))
+                        apply_announced_view();
+                }
+                else
+                {
+                    // During the six-second demonstration hold the announced
+                    // automatic view, but never fight a real player VR override.
+                    if (!manual_override && oroad.get_view_mode() != phase_view)
+                        oroad.set_view_mode(phase_view, true);
+
+                    draw_showcase_text();
+
+                    if (tick_due(phase_due_tick))
+                    {
+                        if (showcase_phase < 2)
+                            begin_view_phase(showcase_phase + 1);
+                        else
+                            finish_showcase();
+                    }
                 }
             }
         }

--- a/src/main/engine/external_output_settings.hpp
+++ b/src/main/engine/external_output_settings.hpp
@@ -341,6 +341,7 @@ private:
         showcase_announcing = false;
         showcase_phase = -1;
         attract_cycle_saved = false;
+        video.clear_text_ram();
     }
 
     bool post_logo_delay_elapsed() const

--- a/src/main/engine/external_output_settings.hpp
+++ b/src/main/engine/external_output_settings.hpp
@@ -160,7 +160,6 @@ private:
     int showcase_phase = -1;
     uint8_t phase_view = ORoad::VIEW_ORIGINAL;
     uint8_t announcement_hold_view = ORoad::VIEW_ORIGINAL;
-    uint32_t phase_start_frame = 0;
     uint32_t phase_due_tick = 0;
     Outrun::AttractRuntimeState attract_cycle_state{};
     bool attract_cycle_saved = false;
@@ -292,7 +291,6 @@ private:
         phase_view = VIEWS[phase];
         announcement_hold_view = oroad.get_view_mode();
         showcase_announcing = true;
-        phase_start_frame = cannonball::frame;
         phase_due_tick = outrun.tick_counter + ANNOUNCE_TIME_TICKS;
     }
 
@@ -303,7 +301,6 @@ private:
         // Camera change only. Vehicle speed, AI, traffic, road position and all
         // other Enhanced Attract logic continue exactly as they normally would.
         oroad.set_view_mode(phase_view, true);
-        phase_start_frame = cannonball::frame;
         phase_due_tick = outrun.tick_counter + VIEW_TIME_TICKS;
     }
 

--- a/src/main/engine/outrun.hpp
+++ b/src/main/engine/outrun.hpp
@@ -180,6 +180,13 @@ class OOutputs;
 class Outrun
 {
 public:
+    struct AttractRuntimeState
+    {
+        uint8_t view;
+        int16_t counter;
+        uint32_t car_increment_backup;
+    };
+
     OOutputs* outputs;
 
     bool freeze_timer;
@@ -220,6 +227,22 @@ public:
 	void vint();
     void init_best_outrunners();
     void select_course(const bool jap, const bool prototype);
+
+    AttractRuntimeState capture_attract_runtime_state() const
+    {
+        AttractRuntimeState state;
+        state.view = attract_view;
+        state.counter = attract_counter;
+        state.car_increment_backup = car_inc_bak;
+        return state;
+    }
+
+    void restore_attract_runtime_state(const AttractRuntimeState& state)
+    {
+        attract_view = state.view;
+        attract_counter = state.counter;
+        car_inc_bak = state.car_increment_backup;
+    }
 
     // JJP - expose skidding state
     bool SkiddingOnRoad();

--- a/src/main/trackloader.cpp
+++ b/src/main/trackloader.cpp
@@ -203,7 +203,7 @@ void TrackLoader::init_layout_tracks(bool jap)
         setup_level(&levels[i], layout, STAGE_ADR);
 
         // CPU 1 Data
-        const uint32_t PATH_ADR = layout->read32(LayOut::PATH);
+        const uint32_t PATH_ADR = layout->read32(LayOut::PATH_OFFSET);
         levels[i].path = &layout->rom[ PATH_ADR + ((ROAD_END_CPU1 * sizeof(uint32_t)) * i) ];
     }
 

--- a/src/main/trackloader.hpp
+++ b/src/main/trackloader.hpp
@@ -16,6 +16,46 @@
 
 #include "globals.hpp"
 
+// Some Windows SDK / platform headers define short, generic macros such as
+// END_PATH. LayOut historically uses similarly named constants for offsets in
+// its binary header. Preprocessor macros are expanded even after `LayOut::`, so
+// clear every potentially colliding field name before declaring the struct.
+// Keeping this protection here makes TrackLoader safe regardless of include
+// order (notably when included by the Windows external-output path).
+#ifdef HEADER
+#undef HEADER
+#endif
+#ifdef PATH_OFFSET
+#undef PATH_OFFSET
+#endif
+#ifdef LEVELS
+#undef LEVELS
+#endif
+#ifdef END_PATH
+#undef END_PATH
+#endif
+#ifdef END_LEVELS
+#undef END_LEVELS
+#endif
+#ifdef SPLIT_PATH
+#undef SPLIT_PATH
+#endif
+#ifdef SPLIT_LEVEL
+#undef SPLIT_LEVEL
+#endif
+#ifdef PAL_SKY
+#undef PAL_SKY
+#endif
+#ifdef PAL_GND
+#undef PAL_GND
+#endif
+#ifdef SPRITE_MAPS
+#undef SPRITE_MAPS
+#endif
+#ifdef HEIGHT_MAPS
+#undef HEIGHT_MAPS
+#endif
+
 // Road Generator Palette Representation
 struct RoadPalette
 {

--- a/src/main/trackloader.hpp
+++ b/src/main/trackloader.hpp
@@ -20,8 +20,6 @@
 // END_PATH. LayOut historically uses similarly named constants for offsets in
 // its binary header. Preprocessor macros are expanded even after `LayOut::`, so
 // clear every potentially colliding field name before declaring the struct.
-// Keeping this protection here makes TrackLoader safe regardless of include
-// order (notably when included by the Windows external-output path).
 #ifdef HEADER
 #undef HEADER
 #endif
@@ -104,15 +102,6 @@ class TrackLoader
 {
 
 public:
-    struct RuntimeState
-    {
-        Level* current_level;
-        uint8_t* current_path;
-        uint32_t curve_offset;
-        uint32_t wh_offset;
-        uint32_t scenery_offset;
-    };
-
     // Reference to stage mapping/ordering table
     uint8_t* stage_data;
 
@@ -141,26 +130,6 @@ public:
 
     TrackLoader();
     ~TrackLoader();
-
-    RuntimeState capture_runtime_state() const
-    {
-        RuntimeState state;
-        state.current_level = current_level;
-        state.current_path = current_path;
-        state.curve_offset = curve_offset;
-        state.wh_offset = wh_offset;
-        state.scenery_offset = scenery_offset;
-        return state;
-    }
-
-    void restore_runtime_state(const RuntimeState& state)
-    {
-        current_level = state.current_level;
-        current_path = state.current_path;
-        curve_offset = state.curve_offset;
-        wh_offset = state.wh_offset;
-        scenery_offset = state.scenery_offset;
-    }
 
     void init(bool jap);
     bool set_layout_track(const char* filename);

--- a/src/main/trackloader.hpp
+++ b/src/main/trackloader.hpp
@@ -16,6 +16,14 @@
 
 #include "globals.hpp"
 
+// Some Windows SDK/include combinations define PATH as a macro. LayOut has
+// used PATH as a binary-header field name for years, so remove the macro at
+// the header boundary before the struct is parsed. This makes inclusion safe
+// regardless of include order.
+#ifdef PATH
+#undef PATH
+#endif
+
 // Road Generator Palette Representation
 struct RoadPalette
 {

--- a/src/main/trackloader.hpp
+++ b/src/main/trackloader.hpp
@@ -64,6 +64,15 @@ class TrackLoader
 {
 
 public:
+    struct RuntimeState
+    {
+        Level* current_level;
+        uint8_t* current_path;
+        uint32_t curve_offset;
+        uint32_t wh_offset;
+        uint32_t scenery_offset;
+    };
+
     // Reference to stage mapping/ordering table
     uint8_t* stage_data;
 
@@ -92,6 +101,26 @@ public:
 
     TrackLoader();
     ~TrackLoader();
+
+    RuntimeState capture_runtime_state() const
+    {
+        RuntimeState state;
+        state.current_level = current_level;
+        state.current_path = current_path;
+        state.curve_offset = curve_offset;
+        state.wh_offset = wh_offset;
+        state.scenery_offset = scenery_offset;
+        return state;
+    }
+
+    void restore_runtime_state(const RuntimeState& state)
+    {
+        current_level = state.current_level;
+        current_path = state.current_path;
+        curve_offset = state.curve_offset;
+        wh_offset = state.wh_offset;
+        scenery_offset = state.scenery_offset;
+    }
 
     void init(bool jap);
     bool set_layout_track(const char* filename);

--- a/src/main/trackloader.hpp
+++ b/src/main/trackloader.hpp
@@ -16,14 +16,6 @@
 
 #include "globals.hpp"
 
-// Some Windows SDK/include combinations define PATH as a macro. LayOut has
-// used PATH as a binary-header field name for years, so remove the macro at
-// the header boundary before the struct is parsed. This makes inclusion safe
-// regardless of include order.
-#ifdef PATH
-#undef PATH
-#endif
-
 // Road Generator Palette Representation
 struct RoadPalette
 {
@@ -54,8 +46,8 @@ struct LayOut
     static const uint32_t EXPECTED_VERSION = 1;
 
     static const uint32_t HEADER      = 0;
-    static const uint32_t PATH        = HEADER      + sizeof(uint32_t) + sizeof(uint8_t);
-    static const uint32_t LEVELS      = PATH        + sizeof(uint32_t);
+    static const uint32_t PATH_OFFSET = HEADER      + sizeof(uint32_t) + sizeof(uint8_t);
+    static const uint32_t LEVELS      = PATH_OFFSET + sizeof(uint32_t);
     static const uint32_t END_PATH    = LEVELS      + (STAGES * sizeof(uint32_t));
     static const uint32_t END_LEVELS  = END_PATH    + sizeof(uint32_t);
     static const uint32_t SPLIT_PATH  = END_LEVELS  + (5 * sizeof(uint32_t));


### PR DESCRIPTION
Alternative to PR #4 that keeps the proven showcase branch intact while testing a more natural presentation.

- continues the existing Enhanced Attract drive instead of loading a disposable Coconut Beach demo scene
- preserves the native Enhanced Attract vehicle state: no speed, accelerator, brake, steering, traffic or road-position override
- every 80-second GS_ATTRACT driving section gets one showcase at the real halfway point (0x40 / 40 seconds remaining)
- after every High Score / Logo cycle, the resumed driving section additionally gets an early showcase after 4.5 seconds
- menu visits pause both schedules naturally because the midpoint follows OutRun's own attract countdown and the post-logo delay follows the 30 Hz engine tick counter
- each showcased camera is demonstrated for 6 seconds; camera, view name and dedicated lamp all switch together with no announcement delay
- no engine pause/freeze and no extra road tick are used during view changes
- presents Original, Elevated and Bumper views on the actual running road
- keeps the Music Select-style instruction and blinking view name
- during the showcase, each active view blinks only its own dedicated lamp
- all VIEW1 / VIEW2 / VIEW3 / VIEWPOINT input is ignored for the duration of the presentation
- pressing START in any pre-race state immediately cancels an active showcase and forces VIEW_ORIGINAL; the normal ORoad game initialization also resets to Original again when the run begins
- removes the full engine/road/traffic/sprite/palette snapshot and the TrackLoader runtime snapshot that the disposable demo required
- retains the MSVC-safe LayOut offset names from PR #4

Draft for compile/runtime testing. PR #4 remains unchanged as the fallback implementation.