### PR TITLE
Add Time Trial course records flow

### DIFF
--- a/src/main/engine/external_output_settings.hpp
+++ b/src/main/engine/external_output_settings.hpp
@@ -11,7 +11,9 @@
 #include "engine/oroad.hpp"
 #include "engine/ostats.hpp"
 #include "engine/outrun.hpp"
+#include "engine/time_trial_records.hpp"
 #include "frontend/config.hpp"
+#include "frontend/ttrial.hpp"
 #include "frontend/xml_parser.h"
 #include "sdl2/input.hpp"
 
@@ -82,7 +84,27 @@ public:
         update_showcase();
         reset_view_on_start();
 
-        if (showcase_active)
+        // GS_BEST2 draws the normal FREE PLAY/credits text after the dedicated
+        // Time Trial records tick. This output pass runs later in the frame, so
+        // redraw only the Time Trial page here and let its editor own rows 25-27.
+        // No input is processed a second time by redraw_screen().
+        if (time_trial_records.is_record_screen_active())
+            time_trial_records.redraw_screen();
+
+        // The course selector uses only VIEW1 and the classic/general VIEW
+        // button as Traffic toggles. Reflect that same simple state physically:
+        // both relevant lamps are on for Traffic ON, all view lamps are off for
+        // Traffic OFF, and VIEW2/VIEW3 never participate in this selector.
+        const bool time_trial_selector = time_trial_selector_active();
+        if (time_trial_selector)
+        {
+            const bool traffic_on = time_trial_selector_traffic_enabled();
+            view_lamp = traffic_on ? 1 : 0;
+            view1_lamp = traffic_on ? 1 : 0;
+            view2_lamp = 0;
+            view3_lamp = 0;
+        }
+        else if (showcase_active)
         {
             // The dedicated VR lamps always follow the camera that is actually
             // on screen. View, label and lamp switch in the same update tick.

--- a/src/main/engine/oferrari.cpp
+++ b/src/main/engine/oferrari.cpp
@@ -35,6 +35,11 @@
 #undef tick
 #undef PAL_CYAN
 
+namespace
+{
+    bool ttrial_goal_randomized = false;
+}
+
 void OFerrari::cycle_car_palette()
 {
     const int size = sizeof(FERRARI_PALETTES) / sizeof(FERRARI_PALETTES[0]);
@@ -69,6 +74,25 @@ void OFerrari::tick()
             car_palette_state::set_default(config.engine.car_pal);
             config.save();
         }
+    }
+
+    // A normal OutRun ending ties one of five end animations to the route.
+    // Time Trial repeatedly finishes the same selected course, so choose one
+    // of those five animation sets at random once when its GOAL sequence starts.
+    // The bonus road is already loaded at this point; only the visible character/
+    // celebration animation changes, which keeps the Time Trial course intact.
+    const bool ttrial_goal =
+        outrun.cannonball_mode == Outrun::MODE_TTRIAL &&
+        (outrun.game_state == GS_INIT_BONUS || outrun.game_state == GS_BONUS);
+
+    if (ttrial_goal && !ttrial_goal_randomized)
+    {
+        oanimseq.end_seq = static_cast<uint8_t>(outils::random() % 5);
+        ttrial_goal_randomized = true;
+    }
+    else if (!ttrial_goal)
+    {
+        ttrial_goal_randomized = false;
     }
 
     tick_base();

--- a/src/main/engine/ohiscore.cpp
+++ b/src/main/engine/ohiscore.cpp
@@ -1,9 +1,9 @@
 /***************************************************************************
-    Best Outrunners - CannonBall DX Endless wrapper.
+    Best Outrunners - CannonBall DX score-screen wrapper.
 
     The original score implementation is preserved in ohiscore_base.cpp.
-    Endless substitutes only the game-end init/tick calls; attract-mode score
-    display and Original/Continuous score handling continue to use the exact
+    Endless and Time Trial substitute their dedicated tables only at game end;
+    attract-mode, Original and Continuous score handling continue to use the
     preserved implementation, with a shared stable high-score background.
 ***************************************************************************/
 
@@ -20,6 +20,7 @@
 #include <iostream>
 
 #include "engine/endless_hiscore.hpp"
+#include "engine/time_trial_records.hpp"
 
 #define init init_base
 #define tick tick_base
@@ -30,10 +31,12 @@
 #undef init
 
 EndlessHiScore endless_hiscore;
+TimeTrialRecords time_trial_records;
 
 namespace
 {
     bool endless_score_audio_started = false;
+    bool time_trial_score_audio_started = false;
 
     bool endless_gameover_score_screen()
     {
@@ -43,14 +46,19 @@ namespace
                 outrun.game_state == GS_BEST2);
     }
 
+    bool time_trial_record_screen()
+    {
+        return outrun.cannonball_mode == Outrun::MODE_TTRIAL &&
+               (outrun.game_state == GS_INIT_BEST2 ||
+                outrun.game_state == GS_BEST2);
+    }
+
     void stabilize_score_background()
     {
-        // High-score screens can be entered after many different road profiles
-        // (and Endless can finish on any of the fifteen stages). Reusing the
-        // live road state makes the sunset/horizon sit at different heights.
-        // Use the same flat Stage 1 road baseline and stock Best OutRunners
-        // horizon for every high-score presentation: attract, Original,
-        // Continuous and Endless.
+        // High-score screens can be entered after many different road profiles.
+        // Reusing the live road state makes the sunset/horizon sit at different
+        // heights. Use the same flat Stage 1 baseline and stock Best OutRunners
+        // horizon for every score presentation, including Time Trial Records.
         oroad.init();
         oroad.set_view_mode(ORoad::VIEW_ORIGINAL, true);
         oroad.horizon_base = 0x154;
@@ -63,10 +71,14 @@ namespace
 
 void OHiScore::init()
 {
-    // Keep the attractive, correctly positioned Best OutRunners sunset
-    // consistent on every score screen instead of inheriting the previous
-    // stage's road/horizon state.
     stabilize_score_background();
+
+    if (time_trial_record_screen())
+    {
+        time_trial_score_audio_started = false;
+        time_trial_records.init_screen();
+        return;
+    }
 
     if (!endless_gameover_score_screen())
     {
@@ -84,6 +96,21 @@ void OHiScore::init()
 
 void OHiScore::tick()
 {
+    if (time_trial_record_screen())
+    {
+        // GS_INIT_BEST2 resets FM/WAV immediately after init(). Start the
+        // familiar Last Wave high-score ambience on the first real BEST2 tick.
+        if (!time_trial_score_audio_started && outrun.game_state == GS_BEST2)
+        {
+            osoundint.queue_sound(sound::PCM_WAVE);
+            osoundint.queue_sound(sound::MUSIC_LASTWAVE);
+            time_trial_score_audio_started = true;
+        }
+
+        time_trial_records.tick_screen();
+        return;
+    }
+
     if (endless_gameover_score_screen())
     {
         // GS_INIT_BEST2 queues FM_RESET and clears WAV playback immediately
@@ -106,6 +133,19 @@ void OHiScore::tick()
 
 int OHiScore::score_position()
 {
+    if (time_trial_record_screen())
+    {
+        time_trial_records.finish_flow();
+
+        // GS_BEST2 performs the normal full engine reset immediately after
+        // this call. Switch back to Original first so it initializes Stage 1
+        // and returns to attract mode instead of reloading the Time Trial track.
+        outrun.cannonball_mode = Outrun::MODE_ORIGINAL;
+        outrun.freeze_timer = config.engine.freeze_timer;
+        time_trial_score_audio_started = false;
+        return -1;
+    }
+
     // The preserved GS_BEST2 exit saves Original/Continuous tables when this
     // reports a valid entry. Endless persists its own XML table, so suppress
     // that legacy save and keep hiscores_continuous.xml untouched.

--- a/src/main/engine/ohiscore.cpp
+++ b/src/main/engine/ohiscore.cpp
@@ -12,11 +12,14 @@
 // from unrelated declarations in those headers.
 #include "main.hpp"
 #include "engine/ohud.hpp"
-#include "engine/oinputs.hpp"
+#include "engine/oininputs.hpp"
 #include "engine/oroad.hpp"
 #include "engine/ostats.hpp"
 #include "engine/outils.hpp"
 #include "engine/ohiscore.hpp"
+#include "engine/oinitengine.hpp"
+#include "engine/opalette.hpp"
+#include "engine/otiles.hpp"
 #include <iostream>
 
 #include "engine/endless_hiscore.hpp"
@@ -55,11 +58,33 @@ namespace
 
     void stabilize_score_background()
     {
-        // High-score screens can be entered after many different road profiles.
-        // Reusing the live road state makes the sunset/horizon sit at different
-        // heights. Use the same flat Stage 1 baseline and stock Best OutRunners
-        // horizon for every score presentation, including Time Trial Records.
+        // A score screen can be entered from any stage, and Time Trial in
+        // particular normally leaves the selected course's tilemap and palette
+        // live. Rebuild the complete common Best OutRunners scene instead of
+        // inheriting any part of that course.
         oroad.init();
+        oroad.stage_lookup_off = 0;
+        oinitengine.init_road_seg_master();
+
+        otiles.init();
+        otiles.reset_tiles_pal();
+        otiles.setup_palette_hud();
+        otiles.setup_palette_tilemap();
+        otiles.update_tilemaps(0);
+        otiles.write_tilemap_hw();
+
+        opalette.setup_sky_palette();
+        opalette.setup_ground_color();
+        opalette.setup_road_centre();
+        opalette.setup_road_stripes();
+        opalette.setup_road_side();
+        opalette.setup_road_colour();
+
+        // These are the original dedicated Best OutRunners palette overrides:
+        // shaded red/sunset backdrop plus the black score-screen road.
+        ohiscore.setup_pal_best();
+        ohiscore.setup_road_best();
+
         oroad.set_view_mode(ORoad::VIEW_ORIGINAL, true);
         oroad.horizon_base = 0x154;
         oroad.horizon_set = 1;

--- a/src/main/engine/ohiscore.cpp
+++ b/src/main/engine/ohiscore.cpp
@@ -4,7 +4,7 @@
     The original score implementation is preserved in ohiscore_base.cpp.
     Endless and Time Trial substitute their dedicated tables only at game end;
     attract-mode, Original and Continuous score handling continue to use the
-    preserved implementation, with a shared stable high-score background.
+    preserved implementation.
 ***************************************************************************/
 
 // Pre-include the preserved implementation's dependencies before temporarily
@@ -56,12 +56,23 @@ namespace
                 outrun.game_state == GS_BEST2);
     }
 
+    bool attract_score_screen()
+    {
+        return outrun.game_state == GS_INIT_BEST1 ||
+               outrun.game_state == GS_BEST1;
+    }
+
     void stabilize_score_background()
     {
-        // A score screen can be entered from any stage, and Time Trial in
-        // particular normally leaves the selected course's tilemap and palette
-        // live. Rebuild the complete common Best OutRunners scene instead of
-        // inheriting any part of that course.
+        // Dedicated game-end score screens can be entered from any stage, and
+        // Time Trial in particular normally leaves the selected course's tilemap
+        // and palette live. Rebuild the complete common Best OutRunners scene
+        // for those dedicated screens only.
+        //
+        // IMPORTANT: never call this for GS_INIT_BEST1/GS_BEST1. The original
+        // attract-mode high-score sequence is an organic overlay on the demo
+        // scene that was already running; resetting road/tile/palette state here
+        // makes the road disappear and visibly jumps to a different background.
         oroad.init();
         oroad.stage_lookup_off = 0;
         oinitengine.init_road_seg_master();
@@ -96,6 +107,16 @@ namespace
 
 void OHiScore::init()
 {
+    // Preserve the original attract transition exactly: BEST1 must inherit the
+    // running demo's road, scenery and palette instead of rebuilding a separate
+    // Best OutRunners background. This deliberately leaves every other attract
+    // subsystem untouched.
+    if (attract_score_screen())
+    {
+        init_base();
+        return;
+    }
+
     stabilize_score_background();
 
     if (time_trial_record_screen())

--- a/src/main/engine/ohiscore.cpp
+++ b/src/main/engine/ohiscore.cpp
@@ -12,7 +12,7 @@
 // from unrelated declarations in those headers.
 #include "main.hpp"
 #include "engine/ohud.hpp"
-#include "engine/oininputs.hpp"
+#include "engine/oinputs.hpp"
 #include "engine/oroad.hpp"
 #include "engine/ostats.hpp"
 #include "engine/outils.hpp"

--- a/src/main/engine/omusic.cpp
+++ b/src/main/engine/omusic.cpp
@@ -281,6 +281,17 @@ void OMusic::tick()
 {
     tick_base();
 
+    // The stock Music Select timeout is owned by Outrun::decrement_timers()
+    // immediately after this function returns. Holding both counters at their
+    // initial values makes this selector unlimited without touching any race,
+    // attract or high-score timer behavior.
+    if (outrun.game_state == GS_MUSIC &&
+        !config.selection_timers_enabled())
+    {
+        ostats.time_counter = config.sound.music_timer;
+        ostats.frame_counter = ostats.frame_reset;
+    }
+
     if (outrun.game_state == GS_MUSIC &&
         game_mode_selected == Outrun::MODE_CONT &&
         endless_selected)

--- a/src/main/engine/omusic.cpp
+++ b/src/main/engine/omusic.cpp
@@ -20,6 +20,7 @@
 #include "frontend/menu.hpp"
 #include "directx/ffeedback.hpp"
 
+#include <SDL.h>
 #include <cstring>
 
 #define enable enable_base
@@ -36,6 +37,7 @@ namespace
 {
     const int CAR_COLOR_COUNT = 8;
     int last_endless_music_stage = -1;
+    Uint32 music_select_deadline_ms = 0;
 
     enum MusicModeSelection
     {
@@ -52,6 +54,12 @@ namespace
         while (color >= CAR_COLOR_COUNT)
             color -= CAR_COLOR_COUNT;
         return color;
+    }
+
+    bool music_selection_timed_out()
+    {
+        return music_select_deadline_ms != 0 &&
+            static_cast<Sint32>(SDL_GetTicks() - music_select_deadline_ms) >= 0;
     }
 
     void draw_endless_mode_name()
@@ -94,16 +102,23 @@ void OMusic::enable()
             car_palette_state::get_default(config.engine.car_pal);
     }
 
+    music_select_deadline_ms = 0;
     enable_base();
 
-    // The preserved implementation initializes this from sound.music_timer.
-    // DX now owns one shared selector duration under Game Engine instead, so
-    // override it here with 15 or 30 seconds. OFF is held indefinitely in
-    // tick(), but starts from 30 simply to keep the counter in a valid state.
+    // Do not use Outrun's generic countdown to own Music Select. It jumps
+    // straight to GS_INIT_GAME and therefore bypasses the DX game-mode logic.
+    // Instead keep that legacy counter safely away from zero and use the same
+    // real-time deadline as the Time Trial course selector.
     if (!skip_music_tick)
     {
         const int selection_seconds = config.selection_timer_seconds();
-        ostats.time_counter = selection_seconds == 15 ? 0x15 : 0x30;
+        if (selection_seconds > 0)
+        {
+            music_select_deadline_ms =
+                SDL_GetTicks() + static_cast<Uint32>(selection_seconds) * 1000U;
+        }
+
+        ostats.time_counter = 0x30;
         ostats.frame_counter = ostats.frame_reset;
     }
 
@@ -168,6 +183,8 @@ void OMusic::check_start()
     // Continuous, while Time Trial keeps its existing forced timer behaviour.
     if (start_pressed)
     {
+        music_select_deadline_ms = 0;
+
         if (old_selection == SELECT_ENDLESS)
             outrun.freeze_timer = false;
         else if (old_selection == SELECT_TIME_TRIAL)
@@ -290,14 +307,81 @@ void OMusic::cycle_music()
 
 void OMusic::tick()
 {
+    // A timed Music Select must commit the highlighted game mode exactly like
+    // START. The old engine timeout could not do this because it only changed
+    // game_state. Handle the full DX selection here instead.
+    if (!skip_music_tick &&
+        outrun.game_state == GS_MUSIC &&
+        music_selection_timed_out())
+    {
+        music_select_deadline_ms = 0;
+        config.save();
+
+        if (game_mode_selected == Outrun::MODE_TTRIAL &&
+            outrun.cannonball_mode != Outrun::MODE_TTRIAL)
+        {
+            pending_music_selected = music_selected;
+            return_from_time_trial = true;
+            outrun.freeze_timer = true;
+            outrun.endless_mode = false;
+
+            cannonball::audio.clear_wav();
+            osoundint.queue_sound(sound::FM_RESET);
+            ologo.disable();
+            disable();
+
+            ostats.time_counter = 0x30;
+            ostats.frame_counter = ostats.frame_reset;
+
+            if (menu)
+            {
+                menu->start_time_trial_from_music();
+                return;
+            }
+
+            // Defensive fallback for builds without a frontend menu object.
+            return_from_time_trial = false;
+            game_mode_selected = Outrun::MODE_ORIGINAL;
+        }
+
+        outrun.cannonball_mode = game_mode_selected;
+        outrun.endless_mode =
+            game_mode_selected == Outrun::MODE_CONT && endless_selected;
+
+        if (outrun.endless_mode)
+        {
+            outrun.freeze_timer = false;
+            outrun.custom_traffic = 2;
+        }
+        else if (game_mode_selected == Outrun::MODE_TTRIAL)
+        {
+            outrun.freeze_timer = true;
+        }
+        else
+        {
+            outrun.freeze_timer = config.engine.freeze_timer;
+        }
+
+        if (game_mode_selected == Outrun::MODE_CONT && !outrun.endless_mode)
+            set_continuous_traffic_from_difficulty();
+
+        if (game_mode_selected != Outrun::MODE_TTRIAL)
+            config.load_scores(game_mode_selected == Outrun::MODE_ORIGINAL);
+
+        outrun.game_state = GS_INIT_GAME;
+        ologo.disable();
+        disable();
+
+        ostats.time_counter = 0x30;
+        ostats.frame_counter = ostats.frame_reset;
+        return;
+    }
+
     tick_base();
 
-    // The stock Music Select timeout is owned by Outrun::decrement_timers()
-    // immediately after this function returns. OFF keeps both counters at a
-    // safe starting value, making Music Select unlimited without affecting any
-    // race, attract or high-score timer behavior.
-    if (outrun.game_state == GS_MUSIC &&
-        config.selection_timer_seconds() == 0)
+    // Neutralise the legacy Music Select countdown on every frame. The real
+    // 15/30/OFF behaviour is exclusively owned by music_select_deadline_ms.
+    if (outrun.game_state == GS_MUSIC)
     {
         ostats.time_counter = 0x30;
         ostats.frame_counter = ostats.frame_reset;

--- a/src/main/engine/omusic.cpp
+++ b/src/main/engine/omusic.cpp
@@ -96,6 +96,17 @@ void OMusic::enable()
 
     enable_base();
 
+    // The preserved implementation initializes this from sound.music_timer.
+    // DX now owns one shared selector duration under Game Engine instead, so
+    // override it here with 15 or 30 seconds. OFF is held indefinitely in
+    // tick(), but starts from 30 simply to keep the counter in a valid state.
+    if (!skip_music_tick)
+    {
+        const int selection_seconds = config.selection_timer_seconds();
+        ostats.time_counter = selection_seconds == 15 ? 0x15 : 0x30;
+        ostats.frame_counter = ostats.frame_reset;
+    }
+
     // Endless deliberately shares MODE_CONT. Restore its second VIEW2 state
     // when returning to Music Select after an Endless run.
     endless_selected =
@@ -282,13 +293,13 @@ void OMusic::tick()
     tick_base();
 
     // The stock Music Select timeout is owned by Outrun::decrement_timers()
-    // immediately after this function returns. Holding both counters at their
-    // initial values makes this selector unlimited without touching any race,
-    // attract or high-score timer behavior.
+    // immediately after this function returns. OFF keeps both counters at a
+    // safe starting value, making Music Select unlimited without affecting any
+    // race, attract or high-score timer behavior.
     if (outrun.game_state == GS_MUSIC &&
-        !config.selection_timers_enabled())
+        config.selection_timer_seconds() == 0)
     {
-        ostats.time_counter = config.sound.music_timer;
+        ostats.time_counter = 0x30;
         ostats.frame_counter = ostats.frame_reset;
     }
 

--- a/src/main/engine/ostats.cpp
+++ b/src/main/engine/ostats.cpp
@@ -225,25 +225,82 @@ namespace
             video.write_text16(ohud.translate(x, y), 0);
     }
 
-    void clear_ttrial_no_traffic_score()
+    void clear_text_span(uint16_t x, uint16_t y, uint16_t width)
+    {
+        for (uint16_t i = 0; i < width; ++i)
+            video.write_text16(ohud.translate(x + i, y), 0);
+    }
+
+    bool text_char_at(uint16_t x, uint16_t y, char expected)
+    {
+        return video.read_text8(ohud.translate(x, y) + 1) ==
+            static_cast<uint8_t>(expected);
+    }
+
+    void clean_ttrial_no_traffic_ui()
     {
         if (outrun.cannonball_mode != Outrun::MODE_TTRIAL ||
-            outrun.ttrial.traffic ||
-            outrun.game_state < GS_START1 ||
-            outrun.game_state > GS_BONUS)
+            outrun.ttrial.traffic)
         {
             return;
         }
 
-        // Time Trial itself does not use score for ranking. With Traffic OFF it
-        // has no useful overtaking context either, so remove both the SCORE logo
-        // and the zero score digits from the in-game HUD.
-        ohud.blit_text_new(2, 1, "        ", OHud::GREY);
-        ohud.blit_text_new(2, 2, "        ", OHud::GREY);
+        if (outrun.game_state >= GS_START1 &&
+            outrun.game_state <= GS_BONUS)
+        {
+            // Time Trial draws its SCORE label/value at x=2..10 rather than at
+            // the stock in-game score address. Clear that actual area so the
+            // last remaining zero disappears only in the Traffic OFF class.
+            clear_text_span(2, 1, 10);
+            clear_text_span(2, 2, 10);
+        }
 
-        uint32_t score_addr = 0x110150;
-        for (int i = 0; i < 8; i++)
-            video.write_text16(&score_addr, 0);
+        if (outrun.game_state == GS_GAMEOVER)
+        {
+            // The seven-second Time Trial Results page is drawn before this
+            // late pass. With no traffic there can be no overtakes or vehicle
+            // collisions, so leave only the meaningful CRASHES statistic.
+            clear_text_row(14);
+            clear_text_row(16);
+        }
+
+        if (outrun.game_state == GS_INIT_BEST2 ||
+            outrun.game_state == GS_BEST2)
+        {
+            // The no-traffic records renderer already omits OVT. Remove the
+            // remaining vehicle-collision field and use its freed header space
+            // to spell CRASHES out while keeping the existing crash values in
+            // their right-hand field. Detect the header row so the original
+            // initials timer/alphabet are never touched.
+            uint16_t header_y = 0;
+            uint16_t first_row_y = 0;
+            int visible_rows = 0;
+
+            if (text_char_at(29, 5, 'C') && text_char_at(30, 5, 'O'))
+            {
+                header_y = 5;
+                first_row_y = 7;
+                visible_rows = 15;
+            }
+            else if (text_char_at(29, 4, 'C') && text_char_at(30, 4, 'O'))
+            {
+                header_y = 4;
+                first_row_y = 5;
+                visible_rows = 20;
+            }
+
+            if (header_y)
+            {
+                clear_text_span(28, header_y, 12);
+                ohud.blit_text_new(33, header_y, "CRASHES", OHud::GREY);
+
+                for (int row = 0; row < visible_rows; ++row)
+                    clear_text_span(
+                        28,
+                        static_cast<uint16_t>(first_row_y + row),
+                        6);
+            }
+        }
     }
 
     void clear_ttrial_lap_banner()
@@ -483,9 +540,9 @@ void OStats::do_timers()
         draw_endless_banner();
     }
 
-    // Traffic OFF Time Trial is purely a lap-time challenge. Keep the normal
-    // score HUD out of the way while driving that class.
-    clear_ttrial_no_traffic_score();
+    // This intentionally runs after all normal Time Trial rendering (including
+    // the late records redraw) so Traffic OFF can remove only irrelevant UI.
+    clean_ttrial_no_traffic_ui();
 
     // Draw after the preserved timer code so the lap notification always owns
     // its temporary centre-screen area, including on the final lap as GOAL starts.

--- a/src/main/engine/ostats.cpp
+++ b/src/main/engine/ostats.cpp
@@ -11,6 +11,7 @@
 
 // Load all preserved dependencies before renaming methods so the temporary
 // macros cannot touch declarations in another header.
+#include "engine/audio/osoundint.hpp"
 #include "engine/ohud.hpp"
 #include "engine/omusic.hpp"
 #include "engine/outils.hpp"
@@ -31,6 +32,13 @@ namespace
 {
     const uint8_t ENDLESS_MAX_DIFFICULTY = 7;
 
+    // Five visible flashes, each on/off phase lasting roughly a quarter second
+    // at the 60 Hz OStats tick rate. Total presentation time is about 2.5 sec.
+    const int TTRIAL_LAP_HALF_PHASE_TICKS = 15;
+    const int TTRIAL_LAP_FLASHES = 5;
+    const int TTRIAL_LAP_TOTAL_TICKS =
+        TTRIAL_LAP_HALF_PHASE_TICKS * TTRIAL_LAP_FLASHES * 2;
+
     enum DifficultyBanner
     {
         DIFF_BANNER_NONE = 0,
@@ -43,6 +51,11 @@ namespace
     int endless_banner_ticks = 0;
     DifficultyBanner endless_difficulty_banner = DIFF_BANNER_NONE;
     char endless_banner_text[40] = {0};
+
+    int last_ttrial_lap = -1;
+    int ttrial_lap_banner_ticks = 0;
+    int ttrial_lap_banner_phase = -1;
+    uint8_t ttrial_lap_time[3] = {0, 0, 0};
 
     uint8_t endless_difficulty_rank(uint16_t stage)
     {
@@ -202,6 +215,114 @@ namespace
         endless_difficulty_banner = DIFF_BANNER_NONE;
         endless_banner_text[0] = 0;
     }
+
+    void clear_ttrial_lap_banner()
+    {
+        ohud.blit_text_big(8, "");
+
+        for (uint16_t x = 0; x < 40; x++)
+        {
+            video.write_text16(ohud.translate(x, 11), 0);
+            video.write_text16(ohud.translate(x, 12), 0);
+        }
+    }
+
+    void draw_ttrial_lap_banner()
+    {
+        // Two deliberately different large styles: the existing two-row
+        // headline font for LAP TIME and the bonus-screen large digit font for
+        // the actual time. Position is centred about one third down the screen.
+        ohud.blit_text_big(8, "LAP TIME");
+
+        for (uint16_t x = 0; x < 40; x++)
+        {
+            video.write_text16(ohud.translate(x, 11), 0);
+            video.write_text16(ohud.translate(x, 12), 0);
+        }
+
+        uint32_t addr = ohud.translate(16, 11);
+        const uint16_t APOSTROPHE = 0x835E;
+        const uint16_t QUOTE = 0x835F;
+
+        ohud.blit_large_digit(
+            &addr,
+            static_cast<uint8_t>((ttrial_lap_time[0] & 0x0F) << 1));
+        video.write_text16(&addr, APOSTROPHE);
+        ohud.blit_large_digit(
+            &addr,
+            static_cast<uint8_t>(((ttrial_lap_time[1] >> 4) & 0x0F) << 1));
+        ohud.blit_large_digit(
+            &addr,
+            static_cast<uint8_t>((ttrial_lap_time[1] & 0x0F) << 1));
+        video.write_text16(&addr, QUOTE);
+        ohud.blit_large_digit(
+            &addr,
+            static_cast<uint8_t>(((ttrial_lap_time[2] >> 4) & 0x0F) << 1));
+        ohud.blit_large_digit(
+            &addr,
+            static_cast<uint8_t>((ttrial_lap_time[2] & 0x0F) << 1));
+    }
+
+    void begin_ttrial_lap_banner(int completed_lap, const uint8_t* lap_ms)
+    {
+        if (completed_lap < 0 || completed_lap >= 5 || !lap_ms)
+            return;
+
+        const uint8_t* lap = outrun.ttrial.laptimes[completed_lap];
+        ttrial_lap_time[0] = lap[0];
+        ttrial_lap_time[1] = lap[1];
+        ttrial_lap_time[2] = lap_ms[lap[2]];
+        ttrial_lap_banner_ticks = TTRIAL_LAP_TOTAL_TICKS;
+        ttrial_lap_banner_phase = -1;
+
+        // check_stage() can still create the old small BEST LAP overlay on a
+        // record lap. The new centred banner replaces it for all completed laps.
+        ostats.extend_play_timer = 0;
+        ohud.blit_text1(TEXT1_LAPTIME_CLEAR1);
+        ohud.blit_text1(TEXT1_LAPTIME_CLEAR2);
+    }
+
+    void tick_ttrial_lap_banner()
+    {
+        if (ttrial_lap_banner_ticks <= 0)
+            return;
+
+        const int elapsed =
+            TTRIAL_LAP_TOTAL_TICKS - ttrial_lap_banner_ticks;
+        const int phase = elapsed / TTRIAL_LAP_HALF_PHASE_TICKS;
+        const bool visible = (phase & 1) == 0;
+
+        if (phase != ttrial_lap_banner_phase)
+        {
+            ttrial_lap_banner_phase = phase;
+            if (visible)
+                osoundint.queue_sound(sound::BEEP1);
+        }
+
+        if (visible)
+            draw_ttrial_lap_banner();
+        else
+            clear_ttrial_lap_banner();
+
+        if (--ttrial_lap_banner_ticks == 0)
+        {
+            clear_ttrial_lap_banner();
+            ttrial_lap_banner_phase = -1;
+        }
+    }
+
+    void reset_ttrial_lap_tracking()
+    {
+        if (ttrial_lap_banner_ticks > 0)
+            clear_ttrial_lap_banner();
+
+        last_ttrial_lap = -1;
+        ttrial_lap_banner_ticks = 0;
+        ttrial_lap_banner_phase = -1;
+        ttrial_lap_time[0] = 0;
+        ttrial_lap_time[1] = 0;
+        ttrial_lap_time[2] = 0;
+    }
 }
 
 void OStats::do_timers()
@@ -245,6 +366,27 @@ void OStats::do_timers()
         reset_endless_tracking();
     }
 
+    // check_stage() has already advanced current_lap by the time this wrapper
+    // runs. Detect that edge and capture the just-finished lap from laptimes[].
+    if (outrun.cannonball_mode == Outrun::MODE_TTRIAL)
+    {
+        const int current_lap = static_cast<int>(outrun.ttrial.current_lap);
+
+        if (last_ttrial_lap < 0 || current_lap < last_ttrial_lap)
+        {
+            last_ttrial_lap = current_lap;
+        }
+        else if (current_lap > last_ttrial_lap)
+        {
+            begin_ttrial_lap_banner(current_lap - 1, lap_ms);
+            last_ttrial_lap = current_lap;
+        }
+    }
+    else if (last_ttrial_lap != -1 || ttrial_lap_banner_ticks != 0)
+    {
+        reset_ttrial_lap_tracking();
+    }
+
     do_timers_base();
 
     if (endless_ingame)
@@ -257,6 +399,11 @@ void OStats::do_timers()
 
         draw_endless_banner();
     }
+
+    // Draw after the preserved timer code so the lap notification always owns
+    // its temporary centre-screen area, including on the final lap as GOAL starts.
+    if (outrun.cannonball_mode == Outrun::MODE_TTRIAL)
+        tick_ttrial_lap_banner();
 }
 
 void OStats::init_next_level()

--- a/src/main/engine/ostats.cpp
+++ b/src/main/engine/ostats.cpp
@@ -32,12 +32,12 @@ namespace
 {
     const uint8_t ENDLESS_MAX_DIFFICULTY = 7;
 
-    // Five visible flashes, each on/off phase lasting roughly a quarter second
-    // at the 60 Hz OStats tick rate. Total presentation time is about 2.5 sec.
+    // Normal completed laps keep the existing five flashes. The final lap also
+    // carries the total time, so give that finish presentation eight flashes.
+    // Each visible/hidden half-phase lasts roughly a quarter second at 60 Hz.
     const int TTRIAL_LAP_HALF_PHASE_TICKS = 15;
     const int TTRIAL_LAP_FLASHES = 5;
-    const int TTRIAL_LAP_TOTAL_TICKS =
-        TTRIAL_LAP_HALF_PHASE_TICKS * TTRIAL_LAP_FLASHES * 2;
+    const int TTRIAL_FINAL_LAP_FLASHES = 8;
 
     enum DifficultyBanner
     {
@@ -54,6 +54,7 @@ namespace
 
     int last_ttrial_lap = -1;
     int ttrial_lap_banner_ticks = 0;
+    int ttrial_lap_banner_total_ticks = 0;
     int ttrial_lap_banner_phase = -1;
     uint8_t ttrial_lap_time[3] = {0, 0, 0};
     uint8_t ttrial_total_time[3] = {0, 0, 0};
@@ -224,6 +225,27 @@ namespace
             video.write_text16(ohud.translate(x, y), 0);
     }
 
+    void clear_ttrial_no_traffic_score()
+    {
+        if (outrun.cannonball_mode != Outrun::MODE_TTRIAL ||
+            outrun.ttrial.traffic ||
+            outrun.game_state < GS_START1 ||
+            outrun.game_state > GS_BONUS)
+        {
+            return;
+        }
+
+        // Time Trial itself does not use score for ranking. With Traffic OFF it
+        // has no useful overtaking context either, so remove both the SCORE logo
+        // and the zero score digits from the in-game HUD.
+        ohud.blit_text_new(2, 1, "        ", OHud::GREY);
+        ohud.blit_text_new(2, 2, "        ", OHud::GREY);
+
+        uint32_t score_addr = 0x110150;
+        for (int i = 0; i < 8; i++)
+            video.write_text16(&score_addr, 0);
+    }
+
     void clear_ttrial_lap_banner()
     {
         // Clear both the original TIME graphic rows and the large digit rows.
@@ -323,7 +345,11 @@ namespace
             ttrial_total_time[2] = 0;
         }
 
-        ttrial_lap_banner_ticks = TTRIAL_LAP_TOTAL_TICKS;
+        const int flashes =
+            ttrial_show_total ? TTRIAL_FINAL_LAP_FLASHES : TTRIAL_LAP_FLASHES;
+        ttrial_lap_banner_total_ticks =
+            TTRIAL_LAP_HALF_PHASE_TICKS * flashes * 2;
+        ttrial_lap_banner_ticks = ttrial_lap_banner_total_ticks;
         ttrial_lap_banner_phase = -1;
 
         // check_stage() can still create the old small BEST LAP overlay on a
@@ -339,7 +365,7 @@ namespace
             return;
 
         const int elapsed =
-            TTRIAL_LAP_TOTAL_TICKS - ttrial_lap_banner_ticks;
+            ttrial_lap_banner_total_ticks - ttrial_lap_banner_ticks;
         const int phase = elapsed / TTRIAL_LAP_HALF_PHASE_TICKS;
         const bool visible = (phase & 1) == 0;
 
@@ -358,6 +384,7 @@ namespace
         if (--ttrial_lap_banner_ticks == 0)
         {
             clear_ttrial_lap_banner();
+            ttrial_lap_banner_total_ticks = 0;
             ttrial_lap_banner_phase = -1;
         }
     }
@@ -369,6 +396,7 @@ namespace
 
         last_ttrial_lap = -1;
         ttrial_lap_banner_ticks = 0;
+        ttrial_lap_banner_total_ticks = 0;
         ttrial_lap_banner_phase = -1;
         ttrial_lap_time[0] = 0;
         ttrial_lap_time[1] = 0;
@@ -454,6 +482,10 @@ void OStats::do_timers()
 
         draw_endless_banner();
     }
+
+    // Traffic OFF Time Trial is purely a lap-time challenge. Keep the normal
+    // score HUD out of the way while driving that class.
+    clear_ttrial_no_traffic_score();
 
     // Draw after the preserved timer code so the lap notification always owns
     // its temporary centre-screen area, including on the final lap as GOAL starts.

--- a/src/main/engine/ostats.cpp
+++ b/src/main/engine/ostats.cpp
@@ -56,6 +56,8 @@ namespace
     int ttrial_lap_banner_ticks = 0;
     int ttrial_lap_banner_phase = -1;
     uint8_t ttrial_lap_time[3] = {0, 0, 0};
+    uint8_t ttrial_total_time[3] = {0, 0, 0};
+    bool ttrial_show_total = false;
 
     uint8_t endless_difficulty_rank(uint16_t stage)
     {
@@ -216,51 +218,72 @@ namespace
         endless_banner_text[0] = 0;
     }
 
-    void clear_ttrial_lap_banner()
+    void clear_text_row(uint16_t y)
     {
-        ohud.blit_text_big(8, "");
-
         for (uint16_t x = 0; x < 40; x++)
-        {
-            video.write_text16(ohud.translate(x, 11), 0);
-            video.write_text16(ohud.translate(x, 12), 0);
-        }
+            video.write_text16(ohud.translate(x, y), 0);
     }
 
-    void draw_ttrial_lap_banner()
+    void clear_ttrial_lap_banner()
     {
-        // Two deliberately different large styles: the existing two-row
-        // headline font for LAP TIME and the bonus-screen large digit font for
-        // the actual time. Position is centred about one third down the screen.
-        ohud.blit_text_big(8, "LAP TIME");
+        // Clear both the original TIME graphic rows and the large digit rows.
+        // blit_text_big owns a separate two-row font path, so clear those labels
+        // through the same helper that created them.
+        clear_text_row(8);
+        clear_text_row(9);
+        clear_text_row(11);
+        clear_text_row(12);
+        ohud.blit_text_big(15, "");
+        clear_text_row(18);
+        clear_text_row(19);
+    }
 
-        for (uint16_t x = 0; x < 40; x++)
-        {
-            video.write_text16(ohud.translate(x, 11), 0);
-            video.write_text16(ohud.translate(x, 12), 0);
-        }
+    void draw_ttrial_large_time(uint8_t y, const uint8_t* time)
+    {
+        if (!time)
+            return;
 
-        uint32_t addr = ohud.translate(16, 11);
+        uint32_t addr = ohud.translate(16, y);
         const uint16_t APOSTROPHE = 0x835E;
         const uint16_t QUOTE = 0x835F;
 
         ohud.blit_large_digit(
             &addr,
-            static_cast<uint8_t>((ttrial_lap_time[0] & 0x0F) << 1));
+            static_cast<uint8_t>((time[0] & 0x0F) << 1));
         video.write_text16(&addr, APOSTROPHE);
         ohud.blit_large_digit(
             &addr,
-            static_cast<uint8_t>(((ttrial_lap_time[1] >> 4) & 0x0F) << 1));
+            static_cast<uint8_t>(((time[1] >> 4) & 0x0F) << 1));
         ohud.blit_large_digit(
             &addr,
-            static_cast<uint8_t>((ttrial_lap_time[1] & 0x0F) << 1));
+            static_cast<uint8_t>((time[1] & 0x0F) << 1));
         video.write_text16(&addr, QUOTE);
         ohud.blit_large_digit(
             &addr,
-            static_cast<uint8_t>(((ttrial_lap_time[2] >> 4) & 0x0F) << 1));
+            static_cast<uint8_t>(((time[2] >> 4) & 0x0F) << 1));
         ohud.blit_large_digit(
             &addr,
-            static_cast<uint8_t>((ttrial_lap_time[2] & 0x0F) << 1));
+            static_cast<uint8_t>((time[2] & 0x0F) << 1));
+    }
+
+    void draw_ttrial_lap_banner()
+    {
+        clear_ttrial_lap_banner();
+
+        // Use the original arcade HUD TIME graphic instead of synthesizing a
+        // new LAP TIME heading. Reposition its two source rows to the centre.
+        ohud.blit_text1(18, 8, HUD_TIME1);
+        ohud.blit_text1(18, 9, HUD_TIME2);
+        draw_ttrial_large_time(11, ttrial_lap_time);
+
+        // On the final lap keep the just-completed lap visible and add the full
+        // run time underneath. In the normal three-lap Time Trial this means
+        // lap 3 and the three-lap total appear together as the GOAL sequence starts.
+        if (ttrial_show_total)
+        {
+            ohud.blit_text_big(15, "TOTAL TIME");
+            draw_ttrial_large_time(18, ttrial_total_time);
+        }
     }
 
     void begin_ttrial_lap_banner(int completed_lap, const uint8_t* lap_ms)
@@ -272,6 +295,34 @@ namespace
         ttrial_lap_time[0] = lap[0];
         ttrial_lap_time[1] = lap[1];
         ttrial_lap_time[2] = lap_ms[lap[2]];
+
+        ttrial_show_total =
+            completed_lap + 1 >= static_cast<int>(outrun.ttrial.laps);
+
+        if (ttrial_show_total)
+        {
+            uint32_t total_counter = 0;
+            for (int i = 0; i <= completed_lap; i++)
+            {
+                if (ostats.stage_counters[i] > 0)
+                    total_counter +=
+                        static_cast<uint16_t>(ostats.stage_counters[i]);
+            }
+
+            if (total_counter > 0xFFFF)
+                total_counter = 0xFFFF;
+
+            outils::convert_counter_to_time(
+                static_cast<uint16_t>(total_counter),
+                ttrial_total_time);
+        }
+        else
+        {
+            ttrial_total_time[0] = 0;
+            ttrial_total_time[1] = 0;
+            ttrial_total_time[2] = 0;
+        }
+
         ttrial_lap_banner_ticks = TTRIAL_LAP_TOTAL_TICKS;
         ttrial_lap_banner_phase = -1;
 
@@ -322,6 +373,10 @@ namespace
         ttrial_lap_time[0] = 0;
         ttrial_lap_time[1] = 0;
         ttrial_lap_time[2] = 0;
+        ttrial_total_time[0] = 0;
+        ttrial_total_time[1] = 0;
+        ttrial_total_time[2] = 0;
+        ttrial_show_total = false;
     }
 }
 

--- a/src/main/engine/outrun.cpp
+++ b/src/main/engine/outrun.cpp
@@ -44,23 +44,20 @@
 
 // The preserved Time Trial exit checks input.is_pressed(Input::START). Keep
 // every normal is_pressed() call unchanged, except on the Time Trial GAME OVER
-// screen: suppress physical START, clear the legacy blinking PRESS START row,
-// redraw our Results page, and synthesize a press after five seconds.
-//
-// The replacement deliberately begins with the original method token: the
-// source contains `input.is_pressed(...)`, so a leading parenthesis here would
-// incorrectly expand to `input.(...)`.
+// screen: suppress physical START, clear the old PRESS START row, redraw the
+// Results page and synthesize a press after five seconds. When that happens we
+// move to GS_INIT_BEST2 before the preserved assignment executes.
 #define is_pressed(ARG) \
     is_pressed(ARG) && !time_trial_records.suppress_physical_input(ARG) || \
     (time_trial_records.suppress_physical_input(ARG) && \
-     (video.clear_text_ram(), time_trial_records.synthetic_input(ARG)))
+     (video.clear_text_ram(), time_trial_records.synthetic_input(ARG)) && \
+     (time_trial_records.begin_records_transition(), game_state = GS_INIT_BEST2, true))
 
-// STATE_INIT_MENU occurs only in the preserved Time Trial GAME OVER exit. The
-// original `if` has no braces, so this replacement must remain one expression
-// statement. Comma operators perform all three actions only when the synthetic
-// START condition is true.
-#define STATE_INIT_MENU \
-    STATE_GAME, time_trial_records.begin_records_transition(), game_state = GS_INIT_BEST2
+// The old Time Trial branch assigns STATE_INIT_MENU after its START check.
+// At this point our synthetic-input hook above has already selected
+// GS_INIT_BEST2, so keep the outer CannonBall state in-game. This removes the
+// frontend-menu route completely rather than trying to undo it afterwards.
+#define STATE_INIT_MENU STATE_GAME
 
 #include "outrun_base.cpp"
 

--- a/src/main/engine/outrun.cpp
+++ b/src/main/engine/outrun.cpp
@@ -36,6 +36,34 @@
 #include "engine/time_trial_records.hpp"
 #include <iostream>
 
+namespace
+{
+    const int TIME_TRIAL_RESULTS_TICKS = 30 * 7;
+    int time_trial_results_ticks = 0;
+
+    bool time_trial_results_input(Input::presses press)
+    {
+        // Keep the existing Results renderer/capture logic, but let DX own the
+        // actual transition time. The preserved helper becomes ready at five
+        // seconds; intentionally ignore that readiness until seven seconds.
+        time_trial_records.synthetic_input(press);
+
+        // The old Results helper draws "RECORDS IN n" on this row. The delay is
+        // automatic now, so erase that implementation detail every frame.
+        ohud.blit_text_new(
+            0,
+            24,
+            "                                        ",
+            OHud::GREY);
+
+        if (++time_trial_results_ticks < TIME_TRIAL_RESULTS_TICKS)
+            return false;
+
+        time_trial_results_ticks = 0;
+        return true;
+    }
+}
+
 // Only while GS_GAMEOVER is executing, make the preserved MODE_CONT branch see
 // Endless as false. It therefore calls init_best_outrunners() instead of the
 // prototype's direct GS_REINIT shortcut. Everywhere else this macro resolves
@@ -45,12 +73,12 @@
 // The preserved Time Trial exit checks input.is_pressed(Input::START). Keep
 // every normal is_pressed() call unchanged, except on the Time Trial GAME OVER
 // screen: suppress physical START, clear the old PRESS START row, redraw the
-// Results page and synthesize a press after five seconds. When that happens we
-// move to GS_INIT_BEST2 before the preserved assignment executes.
+// Results page and synthesize a press after seven seconds. The visible countdown
+// from the older five-second helper is removed by time_trial_results_input().
 #define is_pressed(ARG) \
     is_pressed(ARG) && !time_trial_records.suppress_physical_input(ARG) || \
     (time_trial_records.suppress_physical_input(ARG) && \
-     (video.clear_text_ram(), time_trial_records.synthetic_input(ARG)) && \
+     (video.clear_text_ram(), time_trial_results_input(ARG)) && \
      (time_trial_records.begin_records_transition(), game_state = GS_INIT_BEST2, true))
 
 // The old Time Trial branch assigns STATE_INIT_MENU after its START check.

--- a/src/main/engine/outrun.cpp
+++ b/src/main/engine/outrun.cpp
@@ -44,11 +44,12 @@
 
 // The preserved Time Trial exit checks input.is_pressed(Input::START). Keep
 // every normal is_pressed() call unchanged, except on the Time Trial GAME OVER
-// screen: suppress physical START and synthesize a press after the five-second
-// Results countdown managed by TimeTrialRecords.
+// screen: suppress physical START, clear the legacy blinking PRESS START row,
+// redraw our Results page, and synthesize a press after five seconds.
 #define is_pressed(ARG) \
-    is_pressed(ARG) && !time_trial_records.suppress_physical_input(ARG) || \
-    time_trial_records.synthetic_input(ARG)
+    (is_pressed(ARG) && !time_trial_records.suppress_physical_input(ARG)) || \
+    (time_trial_records.suppress_physical_input(ARG) && \
+     (video.clear_text_ram(), time_trial_records.synthetic_input(ARG)))
 
 // STATE_INIT_MENU occurs only in the preserved Time Trial GAME OVER exit. When
 // the synthetic START fires, remain in the game runtime and enter the existing

--- a/src/main/engine/outrun.cpp
+++ b/src/main/engine/outrun.cpp
@@ -1,17 +1,16 @@
 /***************************************************************************
-    OutRun Engine Entry Point - CannonBall DX Endless wrapper.
+    OutRun Engine Entry Point - CannonBall DX wrappers.
 
     The current engine implementation is preserved in outrun_base.cpp.
-    Endless normally shares MODE_CONT, but its original prototype deliberately
-    skipped the Continuous score screen after GAME OVER. For the dedicated
-    Endless score table we want the normal GS_INIT_BEST2 / GS_BEST2 path,
-    because that path also performs the complete engine reset before returning
-    to attract mode.
+    Endless shares MODE_CONT but uses the normal GS_INIT_BEST2 / GS_BEST2
+    reset path for its dedicated score screen. Time Trial similarly redirects
+    its old PRESS START -> frontend-menu exit into an automatic Results ->
+    Course Records flow.
 ***************************************************************************/
 
 // Pre-include every dependency used by the preserved implementation before the
-// temporary member-name macro below. This guarantees the macro can affect only
-// Outrun method bodies, never declarations in another header.
+// temporary macros below. This guarantees the macros can affect only Outrun
+// method bodies, never declarations in another header.
 #include "main.hpp"
 #include "trackloader.hpp"
 #include "../utils.hpp"
@@ -34,6 +33,7 @@
 #include "engine/otiles.hpp"
 #include "engine/otraffic.hpp"
 #include "engine/outils.hpp"
+#include "engine/time_trial_records.hpp"
 #include <iostream>
 
 // Only while GS_GAMEOVER is executing, make the preserved MODE_CONT branch see
@@ -41,5 +41,23 @@
 // prototype's direct GS_REINIT shortcut. Everywhere else this macro resolves
 // to the real member value, so all Endless gameplay behaviour remains intact.
 #define endless_mode ((game_state == GS_GAMEOVER) ? false : this->endless_mode)
+
+// The preserved Time Trial exit checks input.is_pressed(Input::START). Keep
+// every normal is_pressed() call unchanged, except on the Time Trial GAME OVER
+// screen: suppress physical START and synthesize a press after the five-second
+// Results countdown managed by TimeTrialRecords.
+#define is_pressed(ARG) \
+    is_pressed(ARG) && !time_trial_records.suppress_physical_input(ARG) || \
+    time_trial_records.synthetic_input(ARG)
+
+// STATE_INIT_MENU occurs only in the preserved Time Trial GAME OVER exit. When
+// the synthetic START fires, remain in the game runtime and enter the existing
+// GS_INIT_BEST2 / GS_BEST2 score path instead of returning to the frontend.
+#define STATE_INIT_MENU \
+    STATE_GAME; time_trial_records.begin_records_transition(); game_state = GS_INIT_BEST2
+
 #include "outrun_base.cpp"
+
+#undef STATE_INIT_MENU
+#undef is_pressed
 #undef endless_mode

--- a/src/main/engine/outrun.cpp
+++ b/src/main/engine/outrun.cpp
@@ -46,16 +46,21 @@
 // every normal is_pressed() call unchanged, except on the Time Trial GAME OVER
 // screen: suppress physical START, clear the legacy blinking PRESS START row,
 // redraw our Results page, and synthesize a press after five seconds.
+//
+// The replacement deliberately begins with the original method token: the
+// source contains `input.is_pressed(...)`, so a leading parenthesis here would
+// incorrectly expand to `input.(...)`.
 #define is_pressed(ARG) \
-    (is_pressed(ARG) && !time_trial_records.suppress_physical_input(ARG)) || \
+    is_pressed(ARG) && !time_trial_records.suppress_physical_input(ARG) || \
     (time_trial_records.suppress_physical_input(ARG) && \
      (video.clear_text_ram(), time_trial_records.synthetic_input(ARG)))
 
-// STATE_INIT_MENU occurs only in the preserved Time Trial GAME OVER exit. When
-// the synthetic START fires, remain in the game runtime and enter the existing
-// GS_INIT_BEST2 / GS_BEST2 score path instead of returning to the frontend.
+// STATE_INIT_MENU occurs only in the preserved Time Trial GAME OVER exit. The
+// original `if` has no braces, so this replacement must remain one expression
+// statement. Comma operators perform all three actions only when the synthetic
+// START condition is true.
 #define STATE_INIT_MENU \
-    STATE_GAME; time_trial_records.begin_records_transition(); game_state = GS_INIT_BEST2
+    STATE_GAME, time_trial_records.begin_records_transition(), game_state = GS_INIT_BEST2
 
 #include "outrun_base.cpp"
 

--- a/src/main/engine/time_trial_records.hpp
+++ b/src/main/engine/time_trial_records.hpp
@@ -1,10 +1,9 @@
 /***************************************************************************
     CannonBall DX Time Trial Course Records.
 
-    Time Trial keeps the existing per-track best-lap value for the course
-    selector, but adds a proper three-lap course record for each of the 15
-    tracks. Records store initials, total three-lap time, the best lap from
-    that record run, overtakes, vehicle collisions and crashes.
+    Each of the 15 Time Trial courses owns two independent 20-entry tables:
+    Traffic ON and Traffic OFF. Everything remains in the existing Time Trial
+    XML file so the data can later be reused by an attract-mode overview.
 ***************************************************************************/
 
 #pragma once
@@ -30,6 +29,7 @@ class TimeTrialRecords
 public:
     static const int TRACK_COUNT = 15;
     static const int RECORD_LAPS = 3;
+    static const int TABLE_ENTRIES = 20;
 
     struct Record
     {
@@ -45,8 +45,7 @@ public:
 
     // The preserved engine still asks whether START is held on the old Time
     // Trial GAME OVER screen. The Outrun wrapper redirects that exact query
-    // through these two helpers: physical START is suppressed and a synthetic
-    // press is produced after five seconds instead.
+    // through these helpers and advances automatically after the Results page.
     bool suppress_physical_input(Input::presses press) const
     {
         return press == Input::START &&
@@ -95,15 +94,15 @@ public:
         accel_old =
             oinputs.input_acc >= 0x60 || input.is_pressed(Input::ACCEL);
 
-        if (course_record)
+        if (qualifying_score)
         {
             ostats.time_counter = config.engine.hiscore_timer;
-            save(); // Preserve the record even if initials entry times out.
+            save(); // Preserve the new row even if initials entry times out.
         }
         else
         {
-            // Enough time to read all fifteen course records before returning
-            // automatically to attract mode.
+            // Non-qualifying runs still get enough time to read the table for
+            // the course and traffic class that was just driven.
             ostats.time_counter = 8;
         }
         ostats.frame_counter = ostats.frame_reset;
@@ -123,7 +122,7 @@ public:
     {
         render_records();
 
-        if (!course_record || initials_done)
+        if (!qualifying_score || initials_done)
             return;
 
         update_letter_selection();
@@ -148,16 +147,18 @@ public:
         save_if_needed();
 
         // The legacy frontend used this flag to save the best lap when Time
-        // Trial returned to the menu. We now save directly from this flow, so
-        // clear it to prevent a later menu visit from rewriting the XML file.
+        // Trial returned to the menu. This flow persists its own tables.
         outrun.ttrial.new_high_score = false;
 
         results_active = false;
         results_ticks = 0;
         record_screen_active = false;
         run_captured = false;
-        course_record = false;
+        qualifying_score = false;
+        new_course_record = false;
         current_track = -1;
+        current_traffic_class = TRAFFIC_ON;
+        score_pos = -1;
         initials_done = false;
         initial_selected = 0;
     }
@@ -168,17 +169,30 @@ public:
     }
 
 private:
-    static const int RESULTS_TICKS = 30 * 5;
+    static const int RESULTS_TICKS = 30 * 7;
+    static const int TRAFFIC_CLASSES = 2;
+    static const int TRAFFIC_OFF = 0;
+    static const int TRAFFIC_ON = 1;
 
-    std::array<Record, TRACK_COUNT> records{};
+    using ScoreTable = std::array<Record, TABLE_ENTRIES>;
+
+    // [track][traffic class][position]
+    std::array<std::array<ScoreTable, TRAFFIC_CLASSES>, TRACK_COUNT> records{};
+
+    // Absolute best single lap, independently tracked for each course/class.
+    std::array<std::array<uint16_t, TRAFFIC_CLASSES>, TRACK_COUNT> fastest_laps{};
+
     Record pending{};
 
     bool results_active = false;
     int results_ticks = 0;
     bool record_screen_active = false;
     bool run_captured = false;
-    bool course_record = false;
+    bool qualifying_score = false;
+    bool new_course_record = false;
     int current_track = -1;
+    int current_traffic_class = TRAFFIC_ON;
+    int score_pos = -1;
 
     bool initials_done = false;
     int initial_selected = 0;
@@ -234,10 +248,62 @@ private:
         }
     }
 
+    static const char* traffic_name(int traffic_class)
+    {
+        return traffic_class == TRAFFIC_ON ? "TRAFFIC ON" : "TRAFFIC OFF";
+    }
+
     std::string filename() const
     {
         return config.engine.jap ?
             config.data.file_ttrial_jap : config.data.file_ttrial;
+    }
+
+    static std::string class_tag(int track, int traffic_class)
+    {
+        return "time_trial.track" + Utils::to_string(track) +
+            (traffic_class == TRAFFIC_ON ? ".traffic_on" : ".traffic_off");
+    }
+
+    static void read_record(xml_parser::ptree& data,
+                            const std::string& tag,
+                            Record& record)
+    {
+        record.total_counter = static_cast<uint16_t>(
+            data.get_int(tag + ".total", 0));
+        record.best_lap_counter = static_cast<uint16_t>(
+            data.get_int(tag + ".best_lap", 0));
+        record.overtakes = static_cast<uint16_t>(
+            data.get_int(tag + ".overtakes", 0));
+        record.vehicle_cols = static_cast<uint16_t>(
+            data.get_int(tag + ".vehicle_cols", 0));
+        record.crashes = static_cast<uint16_t>(
+            data.get_int(tag + ".crashes", 0));
+
+        const std::string i1 = data.get_string(tag + ".initial1", "_");
+        const std::string i2 = data.get_string(tag + ".initial2", "_");
+        const std::string i3 = data.get_string(tag + ".initial3", "_");
+
+        record.initial1 = i1.empty() || i1[0] == '_' ? ' ' : i1[0];
+        record.initial2 = i2.empty() || i2[0] == '_' ? ' ' : i2[0];
+        record.initial3 = i3.empty() || i3[0] == '_' ? ' ' : i3[0];
+    }
+
+    static void write_record(xml_parser::ptree& data,
+                             const std::string& tag,
+                             const Record& record)
+    {
+        data.put_int(tag + ".total", record.total_counter);
+        data.put_int(tag + ".best_lap", record.best_lap_counter);
+        data.put_int(tag + ".overtakes", record.overtakes);
+        data.put_int(tag + ".vehicle_cols", record.vehicle_cols);
+        data.put_int(tag + ".crashes", record.crashes);
+        data.put_string(tag + ".initial1",
+            record.initial1 == ' ' ? "_" : std::string(1, record.initial1));
+        data.put_string(tag + ".initial2",
+            record.initial2 == ' ' ? "_" : std::string(1, record.initial2));
+        data.put_string(tag + ".initial3",
+            record.initial3 == ' ' ? "_" : std::string(1, record.initial3));
     }
 
     void begin_results()
@@ -248,6 +314,20 @@ private:
         video.clear_text_ram();
     }
 
+    int insert_position(const ScoreTable& table, uint16_t total) const
+    {
+        if (!total)
+            return -1;
+
+        for (int i = 0; i < TABLE_ENTRIES; i++)
+        {
+            if (!table[i].total_counter || total < table[i].total_counter)
+                return i;
+        }
+
+        return -1;
+    }
+
     void capture_run()
     {
         if (run_captured)
@@ -256,7 +336,11 @@ private:
         load();
 
         current_track = track_from_level(outrun.ttrial.level);
+        current_traffic_class = outrun.ttrial.traffic ? TRAFFIC_ON : TRAFFIC_OFF;
         pending = Record{};
+        qualifying_score = false;
+        new_course_record = false;
+        score_pos = -1;
 
         const int laps = std::min<int>(outrun.ttrial.laps, 5);
         uint32_t total = 0;
@@ -268,8 +352,7 @@ private:
             if (counter_signed <= 0)
                 continue;
 
-            const uint16_t counter =
-                static_cast<uint16_t>(counter_signed);
+            const uint16_t counter = static_cast<uint16_t>(counter_signed);
             total += counter;
 
             if (!best || counter < best)
@@ -285,29 +368,39 @@ private:
         pending.vehicle_cols = outrun.ttrial.vehicle_cols;
         pending.crashes = outrun.ttrial.crashes;
 
-        course_record = false;
-
         if (current_track >= 0)
         {
-            // Preserve the existing absolute best-lap record used by the track
-            // selector, independently from the new three-lap course record.
-            if (best && best < config.ttrial.best_times[current_track])
-                config.ttrial.best_times[current_track] = best;
+            uint16_t& class_best =
+                fastest_laps[current_track][current_traffic_class];
 
+            if (best && (!class_best || best < class_best))
+                class_best = best;
+
+            // The legacy single-lap slots represent the traditional Traffic ON
+            // class. Keep them synchronized for old builds and XML readers.
+            if (current_traffic_class == TRAFFIC_ON && class_best)
+                config.ttrial.best_times[current_track] = class_best;
+
+            // Course leaderboards are deliberately comparable: exactly three
+            // completed laps are required. Other configured lap counts can still
+            // update their class-specific fastest single lap.
             if (laps == RECORD_LAPS && pending.total_counter)
             {
-                const Record& old = records[current_track];
-                course_record =
-                    old.total_counter == 0 ||
-                    pending.total_counter < old.total_counter;
+                ScoreTable& table =
+                    records[current_track][current_traffic_class];
+                score_pos = insert_position(table, pending.total_counter);
 
-                if (course_record)
-                    records[current_track] = pending;
+                if (score_pos >= 0)
+                {
+                    for (int i = TABLE_ENTRIES - 1; i > score_pos; --i)
+                        table[i] = table[i - 1];
+
+                    table[score_pos] = pending;
+                    qualifying_score = true;
+                    new_course_record = score_pos == 0;
+                }
             }
 
-            // Save both legacy best-lap values and the new record data now.
-            // This also handles a new best lap on a run that did not beat the
-            // three-lap course record.
             save();
         }
 
@@ -318,37 +411,72 @@ private:
 
     void load()
     {
-        for (auto& record : records)
-            record = Record{};
+        for (auto& track_tables : records)
+            for (auto& table : track_tables)
+                for (auto& record : table)
+                    record = Record{};
+
+        for (auto& track_best : fastest_laps)
+            for (auto& best : track_best)
+                best = 0;
 
         xml_parser::ptree data("timetrial_scores");
         if (!xml_parser::read_xml(filename(), data))
             return;
 
-        for (int i = 0; i < TRACK_COUNT; i++)
+        for (int track = 0; track < TRACK_COUNT; track++)
         {
-            Record& record = records[i];
-            const std::string tag =
-                "time_trial.record" + Utils::to_string(i);
+            for (int traffic_class = 0; traffic_class < TRAFFIC_CLASSES; traffic_class++)
+            {
+                const std::string base = class_tag(track, traffic_class);
+                fastest_laps[track][traffic_class] = static_cast<uint16_t>(
+                    data.get_int(base + ".fastest_lap", 0));
 
-            record.total_counter = static_cast<uint16_t>(
-                data.get_int(tag + ".total", 0));
-            record.best_lap_counter = static_cast<uint16_t>(
-                data.get_int(tag + ".best_lap", 0));
-            record.overtakes = static_cast<uint16_t>(
-                data.get_int(tag + ".overtakes", 0));
-            record.vehicle_cols = static_cast<uint16_t>(
-                data.get_int(tag + ".vehicle_cols", 0));
-            record.crashes = static_cast<uint16_t>(
-                data.get_int(tag + ".crashes", 0));
+                for (int pos = 0; pos < TABLE_ENTRIES; pos++)
+                {
+                    read_record(
+                        data,
+                        base + ".entry" + Utils::to_string(pos),
+                        records[track][traffic_class][pos]);
+                }
+            }
 
-            const std::string i1 = data.get_string(tag + ".initial1", "_");
-            const std::string i2 = data.get_string(tag + ".initial2", "_");
-            const std::string i3 = data.get_string(tag + ".initial3", "_");
+            // Migrate the old single best-lap and one-record format into the
+            // traditional Traffic ON class. No extra XML files are created.
+            if (!fastest_laps[track][TRAFFIC_ON])
+            {
+                fastest_laps[track][TRAFFIC_ON] = static_cast<uint16_t>(
+                    data.get_int(
+                        "time_trial.score" + Utils::to_string(track),
+                        0));
+            }
 
-            record.initial1 = i1.empty() || i1[0] == '_' ? ' ' : i1[0];
-            record.initial2 = i2.empty() || i2[0] == '_' ? ' ' : i2[0];
-            record.initial3 = i3.empty() || i3[0] == '_' ? ' ' : i3[0];
+            if (!records[track][TRAFFIC_ON][0].total_counter)
+            {
+                read_record(
+                    data,
+                    "time_trial.record" + Utils::to_string(track),
+                    records[track][TRAFFIC_ON][0]);
+            }
+
+            // Older experimental XML may have a course record but no separate
+            // fastest-lap field. Derive it from stored runs when necessary.
+            for (int traffic_class = 0; traffic_class < TRAFFIC_CLASSES; traffic_class++)
+            {
+                if (fastest_laps[track][traffic_class])
+                    continue;
+
+                uint16_t best = 0;
+                for (const Record& record : records[track][traffic_class])
+                {
+                    if (record.best_lap_counter &&
+                        (!best || record.best_lap_counter < best))
+                    {
+                        best = record.best_lap_counter;
+                    }
+                }
+                fastest_laps[track][traffic_class] = best;
+            }
         }
     }
 
@@ -356,31 +484,36 @@ private:
     {
         xml_parser::ptree data("timetrial_scores");
 
-        // Read the current file first so this remains compatible with the old
-        // best-lap format and with any future extra Time Trial fields.
+        // Read first so unknown/future Time Trial fields survive this writer.
         xml_parser::read_xml(filename(), data);
 
-        for (int i = 0; i < TRACK_COUNT; i++)
+        for (int track = 0; track < TRACK_COUNT; track++)
         {
+            for (int traffic_class = 0; traffic_class < TRAFFIC_CLASSES; traffic_class++)
+            {
+                const std::string base = class_tag(track, traffic_class);
+                data.put_int(
+                    base + ".fastest_lap",
+                    fastest_laps[track][traffic_class]);
+
+                for (int pos = 0; pos < TABLE_ENTRIES; pos++)
+                {
+                    write_record(
+                        data,
+                        base + ".entry" + Utils::to_string(pos),
+                        records[track][traffic_class][pos]);
+                }
+            }
+
+            // Compatibility aliases: old CannonBall Time Trial readers see the
+            // Traffic ON fastest lap and its #1 three-lap record.
             data.put_int(
-                "time_trial.score" + Utils::to_string(i),
-                config.ttrial.best_times[i]);
-
-            const Record& record = records[i];
-            const std::string tag =
-                "time_trial.record" + Utils::to_string(i);
-
-            data.put_int(tag + ".total", record.total_counter);
-            data.put_int(tag + ".best_lap", record.best_lap_counter);
-            data.put_int(tag + ".overtakes", record.overtakes);
-            data.put_int(tag + ".vehicle_cols", record.vehicle_cols);
-            data.put_int(tag + ".crashes", record.crashes);
-            data.put_string(tag + ".initial1",
-                record.initial1 == ' ' ? "_" : std::string(1, record.initial1));
-            data.put_string(tag + ".initial2",
-                record.initial2 == ' ' ? "_" : std::string(1, record.initial2));
-            data.put_string(tag + ".initial3",
-                record.initial3 == ' ' ? "_" : std::string(1, record.initial3));
+                "time_trial.score" + Utils::to_string(track),
+                fastest_laps[track][TRAFFIC_ON]);
+            write_record(
+                data,
+                "time_trial.record" + Utils::to_string(track),
+                records[track][TRAFFIC_ON][0]);
         }
 
         xml_parser::write_xml(filename(), data);
@@ -440,6 +573,11 @@ private:
     {
         ohud.blit_text_big(1, "TIME TRIAL RESULTS");
         draw_centered(5, track_name(current_track), OHud::GREEN);
+        ohud.blit_text_new(
+            current_traffic_class == TRAFFIC_ON ? 30 : 29,
+            5,
+            traffic_name(current_traffic_class),
+            OHud::GREEN);
 
         char total_text[16];
         char best_text[16];
@@ -464,82 +602,108 @@ private:
             Utils::to_string(static_cast<int>(pending.crashes)).c_str(),
             OHud::GREEN);
 
-        if (course_record)
+        if (new_course_record)
+        {
             ohud.blit_text_big(20, "NEW COURSE RECORD");
+        }
+        else if (qualifying_score)
+        {
+            const std::string text =
+                "HIGH SCORE " + Utils::to_string(score_pos + 1);
+            ohud.blit_text_big(20, text.c_str());
+        }
         else if (outrun.ttrial.laps != RECORD_LAPS)
+        {
             draw_centered(21, "3 LAPS REQUIRED FOR RECORD", OHud::GREY);
-
-        int seconds_left =
-            (RESULTS_TICKS - results_ticks + 29) / 30;
-        if (seconds_left < 1)
-            seconds_left = 1;
-
-        const std::string countdown =
-            "RECORDS IN " + Utils::to_string(seconds_left);
-        draw_centered(24, countdown.c_str(), OHud::GREEN);
+        }
     }
 
     void render_records()
     {
-        // Match the fixed-column approach used by the Endless table. Long
-        // course names and changing digit counts can never move another field.
-        const uint16_t X_COURSE = 1;
-        const uint16_t X_NAME = 17;
-        const uint16_t X_TIME = 22;
-        const uint16_t X_OVT = 32;
-        const uint16_t X_CR = 37;
+        const uint16_t X_POS   = 0;
+        const uint16_t X_NAME  = 3;
+        const uint16_t X_TOTAL = 8;
+        const uint16_t X_BEST  = 17;
+        const uint16_t X_OVT   = 26;
+        const uint16_t X_COL   = 31;
+        const uint16_t X_CR    = 36;
 
-        ohud.blit_text_new(10, 1, "TIME TRIAL RECORDS", OHud::GREEN);
-        ohud.blit_text_new(X_COURSE, 3, "COURSE", OHud::GREY);
-        ohud.blit_text_new(X_NAME, 3, "NAME", OHud::GREY);
-        ohud.blit_text_new(X_TIME + 2, 3, "TIME", OHud::GREY);
-        ohud.blit_text_new(X_OVT, 3, "OVT", OHud::GREY);
-        ohud.blit_text_new(X_CR, 3, "CR", OHud::GREY);
+        ohud.blit_text_new(10, 0, "TIME TRIAL RECORDS", OHud::GREEN);
+        draw_centered(1, track_name(current_track), OHud::GREEN);
+        ohud.blit_text_new(
+            current_traffic_class == TRAFFIC_ON ? 30 : 29,
+            1,
+            traffic_name(current_traffic_class),
+            OHud::GREEN);
 
-        for (int i = 0; i < TRACK_COUNT; i++)
+        ohud.blit_text_new(X_POS,   3, "#", OHud::GREY);
+        ohud.blit_text_new(X_NAME,  3, "NAME", OHud::GREY);
+        ohud.blit_text_new(X_TOTAL, 3, "TOTAL", OHud::GREY);
+        ohud.blit_text_new(X_BEST,  3, "BEST", OHud::GREY);
+        ohud.blit_text_new(X_OVT,   3, "OVT", OHud::GREY);
+        ohud.blit_text_new(X_COL,   3, "COL", OHud::GREY);
+        ohud.blit_text_new(X_CR,    3, "CR", OHud::GREY);
+
+        if (current_track < 0 || current_track >= TRACK_COUNT)
+            return;
+
+        const ScoreTable& table = records[current_track][current_traffic_class];
+
+        for (int pos = 0; pos < TABLE_ENTRIES; pos++)
         {
-            const uint16_t y = static_cast<uint16_t>(5 + i);
-            const Record& record = records[i];
+            const uint16_t y = static_cast<uint16_t>(5 + pos);
+            const Record& record = table[pos];
             const uint16_t colour =
-                i == current_track ? OHud::GREEN : OHud::GREY;
+                qualifying_score && pos == score_pos ? OHud::GREEN : OHud::GREY;
 
-            // Clear the entire 40-column row first, exactly like the Endless
-            // table. This prevents stale or longer previous values from making
-            // the columns appear to drift.
             ohud.blit_text_new(
                 0,
                 y,
                 "                                        ",
                 OHud::GREY);
 
-            ohud.blit_text_new(X_COURSE, y, track_name(i), colour);
+            ohud.blit_text_new(
+                X_POS,
+                y,
+                Utils::to_string(pos + 1).c_str(),
+                colour);
 
             if (!record.total_counter)
             {
                 ohud.blit_text_new(X_NAME, y, "---", colour);
-                draw_time(X_TIME, y, "--'--\"--", colour);
+                draw_time(X_TOTAL, y, "--'--\"--", colour);
+                draw_time(X_BEST, y, "--'--\"--", colour);
                 ohud.blit_text_new(X_OVT, y, "-", colour);
+                ohud.blit_text_new(X_COL, y, "-", colour);
                 ohud.blit_text_new(X_CR, y, "-", colour);
                 continue;
             }
 
             char initials[4] =
             {
-                record.initial1,
-                record.initial2,
-                record.initial3,
+                record.initial1 == ' ' ? '-' : record.initial1,
+                record.initial2 == ' ' ? '-' : record.initial2,
+                record.initial3 == ' ' ? '-' : record.initial3,
                 0
             };
             ohud.blit_text_new(X_NAME, y, initials, colour);
 
-            char time_text[16];
-            format_counter(record.total_counter, time_text, sizeof(time_text));
-            draw_time(X_TIME, y, time_text, colour);
+            char total_text[16];
+            char best_text[16];
+            format_counter(record.total_counter, total_text, sizeof(total_text));
+            format_counter(record.best_lap_counter, best_text, sizeof(best_text));
+            draw_time(X_TOTAL, y, total_text, colour);
+            draw_time(X_BEST, y, best_text, colour);
 
             ohud.blit_text_new(
                 X_OVT,
                 y,
                 Utils::to_string(static_cast<int>(record.overtakes)).c_str(),
+                colour);
+            ohud.blit_text_new(
+                X_COL,
+                y,
+                Utils::to_string(static_cast<int>(record.vehicle_cols)).c_str(),
                 colour);
             ohud.blit_text_new(
                 X_CR,
@@ -548,10 +712,10 @@ private:
                 colour);
         }
 
-        if (course_record && !initials_done)
+        if (qualifying_score && !initials_done)
         {
-            ohud.blit_text_new(13, 21, "ENTER INITIALS", OHud::GREEN);
-            ohud.blit_text_new(6, 23, "ABCDEFGHIJKLMNOPQRSTUVWXYZ.", OHud::GREY);
+            ohud.blit_text_new(13, 25, "ENTER INITIALS", OHud::GREEN);
+            ohud.blit_text_new(6, 26, "ABCDEFGHIJKLMNOPQRSTUVWXYZ.", OHud::GREY);
 
             const char selected[2] =
             {
@@ -559,15 +723,23 @@ private:
                     ('A' + letter_selected) : '.'),
                 0
             };
-            ohud.blit_text_new(6 + letter_selected, 23, selected, OHud::GREEN);
-            ohud.blit_text_new(7, 25, "STEER LETTER  ACCEL SELECT", OHud::GREY);
+            ohud.blit_text_new(6 + letter_selected, 26, selected, OHud::GREEN);
+            ohud.blit_text_new(7, 27, "STEER LETTER  ACCEL SELECT", OHud::GREY);
         }
-        else if (course_record)
+        else if (qualifying_score)
         {
-            ohud.blit_text_new(0, 21, "                                        ", OHud::GREY);
-            ohud.blit_text_new(0, 23, "                                        ", OHud::GREY);
             ohud.blit_text_new(0, 25, "                                        ", OHud::GREY);
-            ohud.blit_text_new(12, 22, "NEW COURSE RECORD", OHud::GREEN);
+            ohud.blit_text_new(0, 26, "                                        ", OHud::GREY);
+            ohud.blit_text_new(0, 27, "                                        ", OHud::GREY);
+
+            if (new_course_record)
+                ohud.blit_text_new(11, 26, "NEW COURSE RECORD", OHud::GREEN);
+            else
+            {
+                const std::string text =
+                    "HIGH SCORE " + Utils::to_string(score_pos + 1);
+                draw_centered(26, text.c_str(), OHud::GREEN);
+            }
         }
     }
 
@@ -619,14 +791,21 @@ private:
 
     void accept_letter()
     {
-        if (!course_record || current_track < 0 || initial_selected >= 3)
+        if (!qualifying_score ||
+            current_track < 0 || current_track >= TRACK_COUNT ||
+            score_pos < 0 || score_pos >= TABLE_ENTRIES ||
+            initial_selected >= 3)
+        {
             return;
+        }
 
         const char letter =
             static_cast<char>(letter_selected < 26 ?
                 ('A' + letter_selected) : '.');
 
-        Record& record = records[current_track];
+        Record& record =
+            records[current_track][current_traffic_class][score_pos];
+
         if (initial_selected == 0)
             record.initial1 = letter;
         else if (initial_selected == 1)

--- a/src/main/engine/time_trial_records.hpp
+++ b/src/main/engine/time_trial_records.hpp
@@ -647,11 +647,7 @@ private:
     {
         ohud.blit_text_big(1, "TIME TRIAL RESULTS");
         draw_centered(5, track_name(current_track), OHud::GREEN);
-        ohud.blit_text_new(
-            current_traffic_class == TRAFFIC_ON ? 30 : 29,
-            5,
-            traffic_name(current_traffic_class),
-            OHud::GREEN);
+        draw_centered(6, traffic_name(current_traffic_class), OHud::GREEN);
 
         char total_text[16];
         char best_text[16];
@@ -694,22 +690,25 @@ private:
 
     void render_records()
     {
-        // The seven fields exactly partition the 40-column text layer. Header
-        // labels and values are centred independently inside their own field.
+        // Traffic ON keeps the seven-column table including overtakes. With
+        // Traffic OFF overtakes are meaningless, so remove OVT entirely and
+        // redistribute its five columns across the remaining timing/stat fields.
+        const bool show_overtakes = current_traffic_class == TRAFFIC_ON;
+
         const uint16_t X_POS   = 0;
         const uint16_t W_POS   = 3;
         const uint16_t X_NAME  = 3;
         const uint16_t W_NAME  = 5;
         const uint16_t X_TOTAL = 8;
-        const uint16_t W_TOTAL = 9;
-        const uint16_t X_BEST  = 17;
-        const uint16_t W_BEST  = 9;
+        const uint16_t W_TOTAL = show_overtakes ? 9 : 10;
+        const uint16_t X_BEST  = show_overtakes ? 17 : 18;
+        const uint16_t W_BEST  = show_overtakes ? 9 : 10;
         const uint16_t X_OVT   = 26;
         const uint16_t W_OVT   = 5;
-        const uint16_t X_COL   = 31;
-        const uint16_t W_COL   = 5;
-        const uint16_t X_CR    = 36;
-        const uint16_t W_CR    = 4;
+        const uint16_t X_COL   = show_overtakes ? 31 : 28;
+        const uint16_t W_COL   = show_overtakes ? 5 : 6;
+        const uint16_t X_CR    = show_overtakes ? 36 : 34;
+        const uint16_t W_CR    = show_overtakes ? 4 : 6;
 
         const bool entering_initials = qualifying_score && !initials_done;
 
@@ -744,7 +743,8 @@ private:
         draw_field(X_NAME,  W_NAME,  header_y, "NAME",  OHud::GREY);
         draw_field(X_TOTAL, W_TOTAL, header_y, "TOTAL", OHud::GREY);
         draw_field(X_BEST,  W_BEST,  header_y, "BEST",  OHud::GREY);
-        draw_field(X_OVT,   W_OVT,   header_y, "OVT",   OHud::GREY);
+        if (show_overtakes)
+            draw_field(X_OVT, W_OVT, header_y, "OVT", OHud::GREY);
         draw_field(X_COL,   W_COL,   header_y, "COL",   OHud::GREY);
         draw_field(X_CR,    W_CR,    header_y, "CR",    OHud::GREY);
 
@@ -770,7 +770,8 @@ private:
                 draw_field(X_NAME, W_NAME, y, "---", colour);
                 draw_time_field(X_TOTAL, W_TOTAL, y, "--'--\"--", colour);
                 draw_time_field(X_BEST, W_BEST, y, "--'--\"--", colour);
-                draw_field(X_OVT, W_OVT, y, "-", colour);
+                if (show_overtakes)
+                    draw_field(X_OVT, W_OVT, y, "-", colour);
                 draw_field(X_COL, W_COL, y, "-", colour);
                 draw_field(X_CR, W_CR, y, "-", colour);
                 continue;
@@ -799,8 +800,11 @@ private:
             const std::string crashes_text =
                 Utils::to_string(static_cast<int>(record.crashes));
 
-            draw_field(
-                X_OVT, W_OVT, y, overtakes_text.c_str(), colour);
+            if (show_overtakes)
+            {
+                draw_field(
+                    X_OVT, W_OVT, y, overtakes_text.c_str(), colour);
+            }
             draw_field(
                 X_COL, W_COL, y, collisions_text.c_str(), colour);
             draw_field(

--- a/src/main/engine/time_trial_records.hpp
+++ b/src/main/engine/time_trial_records.hpp
@@ -15,6 +15,7 @@
 #include <string>
 
 #include "../utils.hpp"
+#include "engine/oaddresses.hpp"
 #include "engine/ohud.hpp"
 #include "engine/oinputs.hpp"
 #include "engine/oroad.hpp"
@@ -609,6 +610,39 @@ private:
         ohud.blit_text_new(static_cast<uint16_t>(x), y, text, colour);
     }
 
+    void draw_original_initials_editor()
+    {
+        // This is deliberately the same renderer as OHiScore::blit_alphabet():
+        // the ROM supplies the original two-row yellow/blue alphabet and these
+        // three hardware tiles append '.', delete-arrow and ED exactly as the
+        // arcade high-score entry screen does.
+        ohud.blit_text2(TEXT2_ALPHABET);
+
+        uint32_t adr = 0x110BF0;
+        video.write_text16(&adr,       0x8D00); // Full stop, top
+        video.write_text16(adr + 0x7E, 0x8D01); // Full stop, bottom
+        video.write_text16(&adr,       0x8D04); // Delete arrow, top
+        video.write_text16(adr + 0x7E, 0x8D05); // Delete arrow, bottom
+        video.write_text16(&adr,       0x8D02); // ED, top
+        video.write_text16(adr + 0x7E, 0x8D03); // ED, bottom
+
+        // The original routine highlights the selected two-row tile by swapping
+        // only its palette byte to red. Keep the exact same addressing scheme.
+        const uint16_t RED = 0x80;
+        adr = 0x110BBC + (letter_selected << 1);
+        video.write_text8(
+            adr,
+            (video.read_text8(adr) & 1) | RED);
+        video.write_text8(
+            adr + 0x80,
+            (video.read_text8(adr + 0x80) & 1) | RED);
+
+        // Same large red BCD countdown used by the stock Best OutRunners name
+        // entry. Its original address places it in the upper-right of the page.
+        const uint16_t BIG_RED_FONT = 0x8080;
+        ohud.draw_timer2(ostats.time_counter, 0x1101EC, BIG_RED_FONT);
+    }
+
     void render_results()
     {
         ohud.blit_text_big(1, "TIME TRIAL RESULTS");
@@ -677,6 +711,32 @@ private:
         const uint16_t X_CR    = 36;
         const uint16_t W_CR    = 4;
 
+        const bool entering_initials = qualifying_score && !initials_done;
+
+        // The original alphabet lives at rows 23-24 and its timer at rows 3-4.
+        // While entering initials, use a 15-row scrolling window so neither
+        // original element can cover leaderboard data. Once entry is finished,
+        // restore the normal full 20-entry view.
+        const uint16_t header_y = entering_initials ? 5 : 3;
+        const uint16_t first_row_y = entering_initials ? 7 : 5;
+        const int visible_rows = entering_initials ? 15 : TABLE_ENTRIES;
+
+        int display_start = 0;
+        if (entering_initials)
+        {
+            display_start = score_pos - (visible_rows / 2);
+            if (display_start < 0)
+                display_start = 0;
+            else if (display_start > TABLE_ENTRIES - visible_rows)
+                display_start = TABLE_ENTRIES - visible_rows;
+        }
+
+        // Own the complete table/editor area every frame. This removes FREE
+        // PLAY drawn later by the stock BEST2 HUD and also clears the original
+        // alphabet immediately when name entry finishes.
+        for (uint16_t y = 3; y <= 27; ++y)
+            ohud.blit_text_new(0, y, "                                        ", OHud::GREY);
+
         ohud.blit_text_new(10, 0, "TIME TRIAL RECORDS", OHud::GREEN);
         draw_centered(1, track_name(current_track), OHud::GREEN);
         ohud.blit_text_new(
@@ -685,31 +745,26 @@ private:
             traffic_name(current_traffic_class),
             OHud::GREEN);
 
-        draw_field(X_POS,   W_POS,   3, "#",     OHud::GREY);
-        draw_field(X_NAME,  W_NAME,  3, "NAME",  OHud::GREY);
-        draw_field(X_TOTAL, W_TOTAL, 3, "TOTAL", OHud::GREY);
-        draw_field(X_BEST,  W_BEST,  3, "BEST",  OHud::GREY);
-        draw_field(X_OVT,   W_OVT,   3, "OVT",   OHud::GREY);
-        draw_field(X_COL,   W_COL,   3, "COL",   OHud::GREY);
-        draw_field(X_CR,    W_CR,    3, "CR",    OHud::GREY);
+        draw_field(X_POS,   W_POS,   header_y, "#",     OHud::GREY);
+        draw_field(X_NAME,  W_NAME,  header_y, "NAME",  OHud::GREY);
+        draw_field(X_TOTAL, W_TOTAL, header_y, "TOTAL", OHud::GREY);
+        draw_field(X_BEST,  W_BEST,  header_y, "BEST",  OHud::GREY);
+        draw_field(X_OVT,   W_OVT,   header_y, "OVT",   OHud::GREY);
+        draw_field(X_COL,   W_COL,   header_y, "COL",   OHud::GREY);
+        draw_field(X_CR,    W_CR,    header_y, "CR",    OHud::GREY);
 
         if (current_track < 0 || current_track >= TRACK_COUNT)
             return;
 
         const ScoreTable& table = records[current_track][current_traffic_class];
 
-        for (int pos = 0; pos < TABLE_ENTRIES; pos++)
+        for (int row = 0; row < visible_rows; row++)
         {
-            const uint16_t y = static_cast<uint16_t>(5 + pos);
+            const int pos = display_start + row;
+            const uint16_t y = static_cast<uint16_t>(first_row_y + row);
             const Record& record = table[pos];
             const uint16_t colour =
                 qualifying_score && pos == score_pos ? OHud::GREEN : OHud::GREY;
-
-            ohud.blit_text_new(
-                0,
-                y,
-                "                                        ",
-                OHud::GREY);
 
             const std::string rank_text = Utils::to_string(pos + 1);
             draw_field(
@@ -757,55 +812,9 @@ private:
                 X_CR, W_CR, y, crashes_text.c_str(), colour);
         }
 
-        // BEST2 always draws FREE PLAY/credits after OHiScore::tick(). Own the
-        // three bottom editor rows completely so the late redraw can erase it.
-        ohud.blit_text_new(0, 25, "                                        ", OHud::GREY);
-        ohud.blit_text_new(0, 26, "                                        ", OHud::GREY);
-        ohud.blit_text_new(0, 27, "                                        ", OHud::GREY);
-
-        if (qualifying_score && !initials_done)
+        if (entering_initials)
         {
-            ohud.blit_text_new(13, 25, "ENTER INITIALS", OHud::GREEN);
-
-            // Match the original OutRun editor's three special choices:
-            // period, delete and end. Text labels are used for the latter two
-            // so their meaning is unambiguous on every ROM/font set.
-            ohud.blit_text_new(
-                2,
-                26,
-                "ABCDEFGHIJKLMNOPQRSTUVWXYZ. DEL END",
-                OHud::GREY);
-
-            if (letter_selected <= INITIAL_DOT)
-            {
-                const char selected[2] =
-                {
-                    static_cast<char>(
-                        letter_selected < INITIAL_DOT
-                            ? ('A' + letter_selected)
-                            : '.'),
-                    0
-                };
-                ohud.blit_text_new(
-                    static_cast<uint16_t>(2 + letter_selected),
-                    26,
-                    selected,
-                    OHud::GREEN);
-            }
-            else if (letter_selected == INITIAL_DELETE)
-            {
-                ohud.blit_text_new(30, 26, "DEL", OHud::GREEN);
-            }
-            else
-            {
-                ohud.blit_text_new(34, 26, "END", OHud::GREEN);
-            }
-
-            ohud.blit_text_new(
-                5,
-                27,
-                "STEER  ACCEL SELECT  DEL/END",
-                OHud::GREY);
+            draw_original_initials_editor();
         }
         else if (qualifying_score)
         {

--- a/src/main/engine/time_trial_records.hpp
+++ b/src/main/engine/time_trial_records.hpp
@@ -1,0 +1,643 @@
+/***************************************************************************
+    CannonBall DX Time Trial Course Records.
+
+    Time Trial keeps the existing per-track best-lap value for the course
+    selector, but adds a proper three-lap course record for each of the 15
+    tracks. Records store initials, total three-lap time, the best lap from
+    that record run, overtakes, vehicle collisions and crashes.
+***************************************************************************/
+
+#pragma once
+
+#include <array>
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+
+#include "../utils.hpp"
+#include "engine/ohud.hpp"
+#include "engine/oinputs.hpp"
+#include "engine/oroad.hpp"
+#include "engine/ostats.hpp"
+#include "engine/outils.hpp"
+#include "engine/outrun.hpp"
+#include "frontend/config.hpp"
+#include "sdl2/input.hpp"
+
+class TimeTrialRecords
+{
+public:
+    static const int TRACK_COUNT = 15;
+    static const int RECORD_LAPS = 3;
+
+    struct Record
+    {
+        uint16_t total_counter = 0;
+        uint16_t best_lap_counter = 0;
+        uint16_t overtakes = 0;
+        uint16_t vehicle_cols = 0;
+        uint16_t crashes = 0;
+        char initial1 = ' ';
+        char initial2 = ' ';
+        char initial3 = ' ';
+    };
+
+    // The preserved engine still asks whether START is held on the old Time
+    // Trial GAME OVER screen. The Outrun wrapper redirects that exact query
+    // through these two helpers: physical START is suppressed and a synthetic
+    // press is produced after five seconds instead.
+    bool suppress_physical_input(Input::presses press) const
+    {
+        return press == Input::START &&
+               outrun.cannonball_mode == Outrun::MODE_TTRIAL &&
+               outrun.game_state == GS_GAMEOVER;
+    }
+
+    bool synthetic_input(Input::presses press)
+    {
+        if (press != Input::START ||
+            outrun.cannonball_mode != Outrun::MODE_TTRIAL ||
+            outrun.game_state != GS_GAMEOVER)
+        {
+            return false;
+        }
+
+        if (!results_active)
+            begin_results();
+
+        render_results();
+
+        ++results_ticks;
+        return results_ticks >= RESULTS_TICKS;
+    }
+
+    void begin_records_transition()
+    {
+        results_active = false;
+        results_ticks = 0;
+        record_screen_active = false;
+    }
+
+    void init_screen()
+    {
+        if (!run_captured)
+            capture_run();
+
+        record_screen_active = true;
+        initials_done = false;
+        initial_selected = 0;
+        letter_selected = 0;
+        steering_repeat = 0;
+
+        // The accelerator may still be held after crossing the finish line.
+        // Require a release/re-press before accepting the first initial.
+        accel_old =
+            oinputs.input_acc >= 0x60 || input.is_pressed(Input::ACCEL);
+
+        if (course_record)
+        {
+            ostats.time_counter = config.engine.hiscore_timer;
+            save(); // Preserve the record even if initials entry times out.
+        }
+        else
+        {
+            // Enough time to read all fifteen course records before returning
+            // automatically to attract mode.
+            ostats.time_counter = 8;
+        }
+        ostats.frame_counter = ostats.frame_reset;
+
+        // The stock Best OutRunners table is tile based. Clear its page so the
+        // dedicated Time Trial text table is never drawn over stale score data.
+        uint32_t tile_addr = 0x10E000;
+        for (int i = 0; i <= 0x3FF; i++)
+            video.write_tile32(&tile_addr, 0x200020);
+
+        video.clear_text_ram();
+        video.enabled = true;
+        render_records();
+    }
+
+    void tick_screen()
+    {
+        render_records();
+
+        if (!course_record || initials_done)
+            return;
+
+        update_letter_selection();
+
+        const bool accel_now =
+            oinputs.input_acc >= 0x60 || input.is_pressed(Input::ACCEL);
+
+        if (accel_now && !accel_old)
+            accept_letter();
+
+        accel_old = accel_now;
+    }
+
+    void save_if_needed()
+    {
+        if (run_captured)
+            save();
+    }
+
+    void finish_flow()
+    {
+        save_if_needed();
+
+        // The legacy frontend used this flag to save the best lap when Time
+        // Trial returned to the menu. We now save directly from this flow, so
+        // clear it to prevent a later menu visit from rewriting the XML file.
+        outrun.ttrial.new_high_score = false;
+
+        results_active = false;
+        results_ticks = 0;
+        record_screen_active = false;
+        run_captured = false;
+        course_record = false;
+        current_track = -1;
+        initials_done = false;
+        initial_selected = 0;
+    }
+
+    bool is_record_screen_active() const
+    {
+        return record_screen_active;
+    }
+
+private:
+    static const int RESULTS_TICKS = 30 * 5;
+
+    std::array<Record, TRACK_COUNT> records{};
+    Record pending{};
+
+    bool results_active = false;
+    int results_ticks = 0;
+    bool record_screen_active = false;
+    bool run_captured = false;
+    bool course_record = false;
+    int current_track = -1;
+
+    bool initials_done = false;
+    int initial_selected = 0;
+    int letter_selected = 0;
+    int steering_repeat = 0;
+    bool accel_old = false;
+
+    static int bcd_to_decimal(uint8_t value)
+    {
+        return ((value >> 4) * 10) + (value & 0x0F);
+    }
+
+    static int track_from_level(uint8_t level)
+    {
+        static const uint8_t LEVELS[TRACK_COUNT] =
+        {
+            0x00,
+            0x09, 0x08,
+            0x12, 0x11, 0x10,
+            0x1B, 0x1A, 0x19, 0x18,
+            0x24, 0x23, 0x22, 0x21, 0x20
+        };
+
+        for (int i = 0; i < TRACK_COUNT; i++)
+        {
+            if (LEVELS[i] == level)
+                return i;
+        }
+
+        return -1;
+    }
+
+    static const char* track_name(int index)
+    {
+        switch (index)
+        {
+            case 0:  return "COCONUT BEACH";
+            case 1:  return config.engine.jap ? "WHEAT FIELD" : "GATEWAY";
+            case 2:  return config.engine.jap ? "CLOUDY MOUNTAIN" : "DEVILS CANYON";
+            case 3:  return "DESERT";
+            case 4:  return "ALPS";
+            case 5:  return config.engine.jap ? "DEVILS CANYON" : "CLOUDY MOUNTAIN";
+            case 6:  return "WILDERNESS";
+            case 7:  return "OLD CAPITAL";
+            case 8:  return config.engine.jap ? "GATEWAY" : "WHEAT FIELD";
+            case 9:  return "SEASIDE TOWN";
+            case 10: return "VINEYARD";
+            case 11: return "DEATH VALLEY";
+            case 12: return "DESOLATION HILL";
+            case 13: return "AUTOBAHN";
+            case 14: return "LAKESIDE";
+            default: return "UNKNOWN";
+        }
+    }
+
+    std::string filename() const
+    {
+        return config.engine.jap ?
+            config.data.file_ttrial_jap : config.data.file_ttrial;
+    }
+
+    void begin_results()
+    {
+        capture_run();
+        results_active = true;
+        results_ticks = 0;
+        video.clear_text_ram();
+    }
+
+    void capture_run()
+    {
+        if (run_captured)
+            return;
+
+        load();
+
+        current_track = track_from_level(outrun.ttrial.level);
+        pending = Record{};
+
+        const int laps = std::min<int>(outrun.ttrial.laps, 5);
+        uint32_t total = 0;
+        uint16_t best = 0;
+
+        for (int lap = 0; lap < laps; lap++)
+        {
+            const int counter_signed = ostats.stage_counters[lap];
+            if (counter_signed <= 0)
+                continue;
+
+            const uint16_t counter =
+                static_cast<uint16_t>(counter_signed);
+            total += counter;
+
+            if (!best || counter < best)
+                best = counter;
+        }
+
+        if (total > 0xFFFF)
+            total = 0xFFFF;
+
+        pending.total_counter = static_cast<uint16_t>(total);
+        pending.best_lap_counter = best;
+        pending.overtakes = outrun.ttrial.overtakes;
+        pending.vehicle_cols = outrun.ttrial.vehicle_cols;
+        pending.crashes = outrun.ttrial.crashes;
+
+        course_record = false;
+
+        if (current_track >= 0)
+        {
+            // Preserve the existing absolute best-lap record used by the track
+            // selector, independently from the new three-lap course record.
+            if (best && best < config.ttrial.best_times[current_track])
+                config.ttrial.best_times[current_track] = best;
+
+            if (laps == RECORD_LAPS && pending.total_counter)
+            {
+                const Record& old = records[current_track];
+                course_record =
+                    old.total_counter == 0 ||
+                    pending.total_counter < old.total_counter;
+
+                if (course_record)
+                    records[current_track] = pending;
+            }
+
+            // Save both legacy best-lap values and the new record data now.
+            // This also handles a new best lap on a run that did not beat the
+            // three-lap course record.
+            save();
+        }
+
+        // Menu::init() must not perform the old best-lap-only save later.
+        outrun.ttrial.new_high_score = false;
+        run_captured = true;
+    }
+
+    void load()
+    {
+        for (auto& record : records)
+            record = Record{};
+
+        xml_parser::ptree data("timetrial_scores");
+        if (!xml_parser::read_xml(filename(), data))
+            return;
+
+        for (int i = 0; i < TRACK_COUNT; i++)
+        {
+            Record& record = records[i];
+            const std::string tag =
+                "time_trial.record" + Utils::to_string(i);
+
+            record.total_counter = static_cast<uint16_t>(
+                data.get_int(tag + ".total", 0));
+            record.best_lap_counter = static_cast<uint16_t>(
+                data.get_int(tag + ".best_lap", 0));
+            record.overtakes = static_cast<uint16_t>(
+                data.get_int(tag + ".overtakes", 0));
+            record.vehicle_cols = static_cast<uint16_t>(
+                data.get_int(tag + ".vehicle_cols", 0));
+            record.crashes = static_cast<uint16_t>(
+                data.get_int(tag + ".crashes", 0));
+
+            const std::string i1 = data.get_string(tag + ".initial1", "_");
+            const std::string i2 = data.get_string(tag + ".initial2", "_");
+            const std::string i3 = data.get_string(tag + ".initial3", "_");
+
+            record.initial1 = i1.empty() || i1[0] == '_' ? ' ' : i1[0];
+            record.initial2 = i2.empty() || i2[0] == '_' ? ' ' : i2[0];
+            record.initial3 = i3.empty() || i3[0] == '_' ? ' ' : i3[0];
+        }
+    }
+
+    void save()
+    {
+        xml_parser::ptree data("timetrial_scores");
+
+        // Read the current file first so this remains compatible with the old
+        // best-lap format and with any future extra Time Trial fields.
+        xml_parser::read_xml(filename(), data);
+
+        for (int i = 0; i < TRACK_COUNT; i++)
+        {
+            data.put_int(
+                "time_trial.score" + Utils::to_string(i),
+                config.ttrial.best_times[i]);
+
+            const Record& record = records[i];
+            const std::string tag =
+                "time_trial.record" + Utils::to_string(i);
+
+            data.put_int(tag + ".total", record.total_counter);
+            data.put_int(tag + ".best_lap", record.best_lap_counter);
+            data.put_int(tag + ".overtakes", record.overtakes);
+            data.put_int(tag + ".vehicle_cols", record.vehicle_cols);
+            data.put_int(tag + ".crashes", record.crashes);
+            data.put_string(tag + ".initial1",
+                record.initial1 == ' ' ? "_" : std::string(1, record.initial1));
+            data.put_string(tag + ".initial2",
+                record.initial2 == ' ' ? "_" : std::string(1, record.initial2));
+            data.put_string(tag + ".initial3",
+                record.initial3 == ' ' ? "_" : std::string(1, record.initial3));
+        }
+
+        xml_parser::write_xml(filename(), data);
+    }
+
+    static void format_counter(uint16_t counter, char* dst, size_t size)
+    {
+        if (!counter)
+        {
+            std::snprintf(dst, size, "--'--\"--");
+            return;
+        }
+
+        uint8_t converted[3] = {0, 0, 0};
+        outils::convert_counter_to_time(counter, converted);
+
+        std::snprintf(
+            dst,
+            size,
+            "%02u'%02u\"%02u",
+            static_cast<unsigned>(converted[0]),
+            static_cast<unsigned>(bcd_to_decimal(converted[1])),
+            static_cast<unsigned>(bcd_to_decimal(converted[2])));
+    }
+
+    static void draw_time(uint16_t x, uint16_t y, const char* text, uint16_t col)
+    {
+        uint32_t dst = ohud.translate(x, y);
+
+        while (*text)
+        {
+            uint16_t tile = static_cast<uint8_t>(*text++);
+
+            if (tile == '\'')
+                tile = 0x5E;
+            else if (tile == '"')
+                tile = 0x5F;
+            else if (tile == '.')
+                tile = 0x5B;
+
+            video.write_text16(&dst, (col << 8) | tile);
+        }
+    }
+
+    static void draw_centered(uint16_t y, const char* text, uint16_t colour)
+    {
+        const int length = static_cast<int>(std::string(text).size());
+        int x = 20 - (length / 2);
+        if (x < 0)
+            x = 0;
+
+        ohud.blit_text_new(0, y, "                                        ", colour);
+        ohud.blit_text_new(static_cast<uint16_t>(x), y, text, colour);
+    }
+
+    void render_results()
+    {
+        ohud.blit_text_big(1, "TIME TRIAL RESULTS");
+        draw_centered(5, track_name(current_track), OHud::GREEN);
+
+        char total_text[16];
+        char best_text[16];
+        format_counter(pending.total_counter, total_text, sizeof(total_text));
+        format_counter(pending.best_lap_counter, best_text, sizeof(best_text));
+
+        ohud.blit_text_new(8, 9, "TOTAL TIME", OHud::GREY);
+        draw_time(23, 9, total_text, OHud::GREEN);
+        ohud.blit_text_new(8, 11, "BEST LAP", OHud::GREY);
+        draw_time(23, 11, best_text, OHud::GREEN);
+
+        ohud.blit_text_new(8, 14, "OVERTAKES", OHud::GREY);
+        ohud.blit_text_new(28, 14,
+            Utils::to_string(static_cast<int>(pending.overtakes)).c_str(),
+            OHud::GREEN);
+        ohud.blit_text_new(8, 16, "VEHICLE COLLISIONS", OHud::GREY);
+        ohud.blit_text_new(28, 16,
+            Utils::to_string(static_cast<int>(pending.vehicle_cols)).c_str(),
+            OHud::GREEN);
+        ohud.blit_text_new(8, 18, "CRASHES", OHud::GREY);
+        ohud.blit_text_new(28, 18,
+            Utils::to_string(static_cast<int>(pending.crashes)).c_str(),
+            OHud::GREEN);
+
+        if (course_record)
+            ohud.blit_text_big(20, "NEW COURSE RECORD");
+        else if (outrun.ttrial.laps != RECORD_LAPS)
+            draw_centered(21, "3 LAPS REQUIRED FOR RECORD", OHud::GREY);
+
+        int seconds_left =
+            (RESULTS_TICKS - results_ticks + 29) / 30;
+        if (seconds_left < 1)
+            seconds_left = 1;
+
+        const std::string countdown =
+            "RECORDS IN " + Utils::to_string(seconds_left);
+        draw_centered(24, countdown.c_str(), OHud::GREEN);
+    }
+
+    void render_records()
+    {
+        const uint16_t X_COURSE = 0;
+        const uint16_t X_NAME = 17;
+        const uint16_t X_TIME = 21;
+        const uint16_t X_OVT = 31;
+        const uint16_t X_CR = 36;
+
+        ohud.blit_text_new(10, 1, "TIME TRIAL RECORDS", OHud::GREEN);
+        ohud.blit_text_new(X_COURSE, 3, "COURSE", OHud::GREY);
+        ohud.blit_text_new(X_NAME, 3, "NAME", OHud::GREY);
+        ohud.blit_text_new(X_TIME + 1, 3, "TIME", OHud::GREY);
+        ohud.blit_text_new(X_OVT, 3, "OVT", OHud::GREY);
+        ohud.blit_text_new(X_CR, 3, "CR", OHud::GREY);
+
+        for (int i = 0; i < TRACK_COUNT; i++)
+        {
+            const uint16_t y = static_cast<uint16_t>(5 + i);
+            const Record& record = records[i];
+            const uint16_t colour =
+                i == current_track ? OHud::GREEN : OHud::GREY;
+
+            ohud.blit_text_new(
+                X_COURSE,
+                y,
+                "                ",
+                colour);
+            ohud.blit_text_new(X_COURSE, y, track_name(i), colour);
+
+            if (!record.total_counter)
+            {
+                ohud.blit_text_new(X_NAME, y, "---", colour);
+                draw_time(X_TIME, y, "--'--\"--", colour);
+                ohud.blit_text_new(X_OVT, y, "-", colour);
+                ohud.blit_text_new(X_CR, y, "-", colour);
+                continue;
+            }
+
+            char initials[4] =
+            {
+                record.initial1,
+                record.initial2,
+                record.initial3,
+                0
+            };
+            ohud.blit_text_new(X_NAME, y, initials, colour);
+
+            char time_text[16];
+            format_counter(record.total_counter, time_text, sizeof(time_text));
+            draw_time(X_TIME, y, time_text, colour);
+
+            ohud.blit_text_new(
+                X_OVT,
+                y,
+                Utils::to_string(static_cast<int>(record.overtakes)).c_str(),
+                colour);
+            ohud.blit_text_new(
+                X_CR,
+                y,
+                Utils::to_string(static_cast<int>(record.crashes)).c_str(),
+                colour);
+        }
+
+        if (course_record && !initials_done)
+        {
+            ohud.blit_text_new(13, 21, "ENTER INITIALS", OHud::GREEN);
+            ohud.blit_text_new(6, 23, "ABCDEFGHIJKLMNOPQRSTUVWXYZ.", OHud::GREY);
+
+            const char selected[2] =
+            {
+                static_cast<char>(letter_selected < 26 ?
+                    ('A' + letter_selected) : '.'),
+                0
+            };
+            ohud.blit_text_new(6 + letter_selected, 23, selected, OHud::GREEN);
+            ohud.blit_text_new(7, 25, "STEER LETTER  ACCEL SELECT", OHud::GREY);
+        }
+        else if (course_record)
+        {
+            ohud.blit_text_new(0, 21, "                                        ", OHud::GREY);
+            ohud.blit_text_new(0, 23, "                                        ", OHud::GREY);
+            ohud.blit_text_new(0, 25, "                                        ", OHud::GREY);
+            ohud.blit_text_new(12, 22, "NEW COURSE RECORD", OHud::GREEN);
+        }
+    }
+
+    void update_letter_selection()
+    {
+        int direction = 0;
+
+        if (input.has_pressed(Input::LEFT))
+            direction = -1;
+        else if (input.has_pressed(Input::RIGHT))
+            direction = 1;
+        else
+        {
+            const int steering =
+                (oinputs.input_steering & 0xFF) - 0x80;
+
+            if (steering <= -0x30)
+                direction = -1;
+            else if (steering >= 0x30)
+                direction = 1;
+
+            if (direction)
+            {
+                if (steering_repeat > 0)
+                {
+                    --steering_repeat;
+                    direction = 0;
+                }
+                else
+                {
+                    steering_repeat = 5;
+                }
+            }
+            else
+            {
+                steering_repeat = 0;
+            }
+        }
+
+        if (!direction)
+            return;
+
+        letter_selected += direction;
+        if (letter_selected < 0)
+            letter_selected = 26;
+        else if (letter_selected > 26)
+            letter_selected = 0;
+    }
+
+    void accept_letter()
+    {
+        if (!course_record || current_track < 0 || initial_selected >= 3)
+            return;
+
+        const char letter =
+            static_cast<char>(letter_selected < 26 ?
+                ('A' + letter_selected) : '.');
+
+        Record& record = records[current_track];
+        if (initial_selected == 0)
+            record.initial1 = letter;
+        else if (initial_selected == 1)
+            record.initial2 = letter;
+        else
+            record.initial3 = letter;
+
+        ++initial_selected;
+        save();
+
+        if (initial_selected >= 3)
+        {
+            initials_done = true;
+            ostats.frame_counter = ostats.frame_reset;
+            ostats.time_counter = 3;
+        }
+    }
+};
+
+extern TimeTrialRecords time_trial_records;

--- a/src/main/engine/time_trial_records.hpp
+++ b/src/main/engine/time_trial_records.hpp
@@ -136,6 +136,15 @@ public:
         accel_old = accel_now;
     }
 
+    // Called from the late output pass after the stock BEST2 code has drawn its
+    // normal FREE PLAY/credits row. Redrawing here keeps the dedicated Time
+    // Trial editor authoritative without processing input a second time.
+    void redraw_screen()
+    {
+        if (record_screen_active)
+            render_records();
+    }
+
     void save_if_needed()
     {
         if (run_captured)
@@ -173,6 +182,10 @@ private:
     static const int TRAFFIC_CLASSES = 2;
     static const int TRAFFIC_OFF = 0;
     static const int TRAFFIC_ON = 1;
+
+    static const int INITIAL_DOT = 26;
+    static const int INITIAL_DELETE = 27;
+    static const int INITIAL_END = 28;
 
     using ScoreTable = std::array<Record, TABLE_ENTRIES>;
 
@@ -558,6 +571,33 @@ private:
         }
     }
 
+    static uint16_t field_x(uint16_t x, uint16_t width, const char* text)
+    {
+        int length = static_cast<int>(std::string(text).size());
+        if (length > width)
+            length = width;
+
+        return static_cast<uint16_t>(x + ((width - length) / 2));
+    }
+
+    static void draw_field(uint16_t x,
+                           uint16_t width,
+                           uint16_t y,
+                           const char* text,
+                           uint16_t colour)
+    {
+        ohud.blit_text_new(field_x(x, width, text), y, text, colour);
+    }
+
+    static void draw_time_field(uint16_t x,
+                                uint16_t width,
+                                uint16_t y,
+                                const char* text,
+                                uint16_t colour)
+    {
+        draw_time(field_x(x, width, text), y, text, colour);
+    }
+
     static void draw_centered(uint16_t y, const char* text, uint16_t colour)
     {
         const int length = static_cast<int>(std::string(text).size());
@@ -620,13 +660,22 @@ private:
 
     void render_records()
     {
+        // The seven fields exactly partition the 40-column text layer. Header
+        // labels and values are centred independently inside their own field.
         const uint16_t X_POS   = 0;
+        const uint16_t W_POS   = 3;
         const uint16_t X_NAME  = 3;
+        const uint16_t W_NAME  = 5;
         const uint16_t X_TOTAL = 8;
+        const uint16_t W_TOTAL = 9;
         const uint16_t X_BEST  = 17;
+        const uint16_t W_BEST  = 9;
         const uint16_t X_OVT   = 26;
+        const uint16_t W_OVT   = 5;
         const uint16_t X_COL   = 31;
+        const uint16_t W_COL   = 5;
         const uint16_t X_CR    = 36;
+        const uint16_t W_CR    = 4;
 
         ohud.blit_text_new(10, 0, "TIME TRIAL RECORDS", OHud::GREEN);
         draw_centered(1, track_name(current_track), OHud::GREEN);
@@ -636,13 +685,13 @@ private:
             traffic_name(current_traffic_class),
             OHud::GREEN);
 
-        ohud.blit_text_new(X_POS,   3, "#", OHud::GREY);
-        ohud.blit_text_new(X_NAME,  3, "NAME", OHud::GREY);
-        ohud.blit_text_new(X_TOTAL, 3, "TOTAL", OHud::GREY);
-        ohud.blit_text_new(X_BEST,  3, "BEST", OHud::GREY);
-        ohud.blit_text_new(X_OVT,   3, "OVT", OHud::GREY);
-        ohud.blit_text_new(X_COL,   3, "COL", OHud::GREY);
-        ohud.blit_text_new(X_CR,    3, "CR", OHud::GREY);
+        draw_field(X_POS,   W_POS,   3, "#",     OHud::GREY);
+        draw_field(X_NAME,  W_NAME,  3, "NAME",  OHud::GREY);
+        draw_field(X_TOTAL, W_TOTAL, 3, "TOTAL", OHud::GREY);
+        draw_field(X_BEST,  W_BEST,  3, "BEST",  OHud::GREY);
+        draw_field(X_OVT,   W_OVT,   3, "OVT",   OHud::GREY);
+        draw_field(X_COL,   W_COL,   3, "COL",   OHud::GREY);
+        draw_field(X_CR,    W_CR,    3, "CR",    OHud::GREY);
 
         if (current_track < 0 || current_track >= TRACK_COUNT)
             return;
@@ -662,20 +711,18 @@ private:
                 "                                        ",
                 OHud::GREY);
 
-            ohud.blit_text_new(
-                X_POS,
-                y,
-                Utils::to_string(pos + 1).c_str(),
-                colour);
+            const std::string rank_text = Utils::to_string(pos + 1);
+            draw_field(
+                X_POS, W_POS, y, rank_text.c_str(), colour);
 
             if (!record.total_counter)
             {
-                ohud.blit_text_new(X_NAME, y, "---", colour);
-                draw_time(X_TOTAL, y, "--'--\"--", colour);
-                draw_time(X_BEST, y, "--'--\"--", colour);
-                ohud.blit_text_new(X_OVT, y, "-", colour);
-                ohud.blit_text_new(X_COL, y, "-", colour);
-                ohud.blit_text_new(X_CR, y, "-", colour);
+                draw_field(X_NAME, W_NAME, y, "---", colour);
+                draw_time_field(X_TOTAL, W_TOTAL, y, "--'--\"--", colour);
+                draw_time_field(X_BEST, W_BEST, y, "--'--\"--", colour);
+                draw_field(X_OVT, W_OVT, y, "-", colour);
+                draw_field(X_COL, W_COL, y, "-", colour);
+                draw_field(X_CR, W_CR, y, "-", colour);
                 continue;
             }
 
@@ -686,52 +733,82 @@ private:
                 record.initial3 == ' ' ? '-' : record.initial3,
                 0
             };
-            ohud.blit_text_new(X_NAME, y, initials, colour);
+            draw_field(X_NAME, W_NAME, y, initials, colour);
 
             char total_text[16];
             char best_text[16];
             format_counter(record.total_counter, total_text, sizeof(total_text));
             format_counter(record.best_lap_counter, best_text, sizeof(best_text));
-            draw_time(X_TOTAL, y, total_text, colour);
-            draw_time(X_BEST, y, best_text, colour);
+            draw_time_field(X_TOTAL, W_TOTAL, y, total_text, colour);
+            draw_time_field(X_BEST, W_BEST, y, best_text, colour);
 
-            ohud.blit_text_new(
-                X_OVT,
-                y,
-                Utils::to_string(static_cast<int>(record.overtakes)).c_str(),
-                colour);
-            ohud.blit_text_new(
-                X_COL,
-                y,
-                Utils::to_string(static_cast<int>(record.vehicle_cols)).c_str(),
-                colour);
-            ohud.blit_text_new(
-                X_CR,
-                y,
-                Utils::to_string(static_cast<int>(record.crashes)).c_str(),
-                colour);
+            const std::string overtakes_text =
+                Utils::to_string(static_cast<int>(record.overtakes));
+            const std::string collisions_text =
+                Utils::to_string(static_cast<int>(record.vehicle_cols));
+            const std::string crashes_text =
+                Utils::to_string(static_cast<int>(record.crashes));
+
+            draw_field(
+                X_OVT, W_OVT, y, overtakes_text.c_str(), colour);
+            draw_field(
+                X_COL, W_COL, y, collisions_text.c_str(), colour);
+            draw_field(
+                X_CR, W_CR, y, crashes_text.c_str(), colour);
         }
+
+        // BEST2 always draws FREE PLAY/credits after OHiScore::tick(). Own the
+        // three bottom editor rows completely so the late redraw can erase it.
+        ohud.blit_text_new(0, 25, "                                        ", OHud::GREY);
+        ohud.blit_text_new(0, 26, "                                        ", OHud::GREY);
+        ohud.blit_text_new(0, 27, "                                        ", OHud::GREY);
 
         if (qualifying_score && !initials_done)
         {
             ohud.blit_text_new(13, 25, "ENTER INITIALS", OHud::GREEN);
-            ohud.blit_text_new(6, 26, "ABCDEFGHIJKLMNOPQRSTUVWXYZ.", OHud::GREY);
 
-            const char selected[2] =
+            // Match the original OutRun editor's three special choices:
+            // period, delete and end. Text labels are used for the latter two
+            // so their meaning is unambiguous on every ROM/font set.
+            ohud.blit_text_new(
+                2,
+                26,
+                "ABCDEFGHIJKLMNOPQRSTUVWXYZ. DEL END",
+                OHud::GREY);
+
+            if (letter_selected <= INITIAL_DOT)
             {
-                static_cast<char>(letter_selected < 26 ?
-                    ('A' + letter_selected) : '.'),
-                0
-            };
-            ohud.blit_text_new(6 + letter_selected, 26, selected, OHud::GREEN);
-            ohud.blit_text_new(7, 27, "STEER LETTER  ACCEL SELECT", OHud::GREY);
+                const char selected[2] =
+                {
+                    static_cast<char>(
+                        letter_selected < INITIAL_DOT
+                            ? ('A' + letter_selected)
+                            : '.'),
+                    0
+                };
+                ohud.blit_text_new(
+                    static_cast<uint16_t>(2 + letter_selected),
+                    26,
+                    selected,
+                    OHud::GREEN);
+            }
+            else if (letter_selected == INITIAL_DELETE)
+            {
+                ohud.blit_text_new(30, 26, "DEL", OHud::GREEN);
+            }
+            else
+            {
+                ohud.blit_text_new(34, 26, "END", OHud::GREEN);
+            }
+
+            ohud.blit_text_new(
+                5,
+                27,
+                "STEER  ACCEL SELECT  DEL/END",
+                OHud::GREY);
         }
         else if (qualifying_score)
         {
-            ohud.blit_text_new(0, 25, "                                        ", OHud::GREY);
-            ohud.blit_text_new(0, 26, "                                        ", OHud::GREY);
-            ohud.blit_text_new(0, 27, "                                        ", OHud::GREY);
-
             if (new_course_record)
                 ohud.blit_text_new(11, 26, "NEW COURSE RECORD", OHud::GREEN);
             else
@@ -782,29 +859,68 @@ private:
         if (!direction)
             return;
 
+        const int first_option =
+            initial_selected >= 3 ? INITIAL_DELETE : 0;
+
         letter_selected += direction;
-        if (letter_selected < 0)
-            letter_selected = 26;
-        else if (letter_selected > 26)
-            letter_selected = 0;
+        if (letter_selected < first_option)
+            letter_selected = INITIAL_END;
+        else if (letter_selected > INITIAL_END)
+            letter_selected = first_option;
+    }
+
+    void finish_initials_entry()
+    {
+        initials_done = true;
+        save();
+        ostats.frame_counter = ostats.frame_reset;
+        ostats.time_counter = 3;
     }
 
     void accept_letter()
     {
         if (!qualifying_score ||
             current_track < 0 || current_track >= TRACK_COUNT ||
-            score_pos < 0 || score_pos >= TABLE_ENTRIES ||
-            initial_selected >= 3)
+            score_pos < 0 || score_pos >= TABLE_ENTRIES)
         {
             return;
         }
 
-        const char letter =
-            static_cast<char>(letter_selected < 26 ?
-                ('A' + letter_selected) : '.');
-
         Record& record =
             records[current_track][current_traffic_class][score_pos];
+
+        if (letter_selected == INITIAL_END)
+        {
+            finish_initials_entry();
+            return;
+        }
+
+        if (letter_selected == INITIAL_DELETE)
+        {
+            if (initial_selected > 0)
+            {
+                --initial_selected;
+
+                if (initial_selected == 0)
+                    record.initial1 = ' ';
+                else if (initial_selected == 1)
+                    record.initial2 = ' ';
+                else
+                    record.initial3 = ' ';
+
+                save();
+            }
+            return;
+        }
+
+        if (initial_selected >= 3)
+            return;
+
+        const char letter =
+            static_cast<char>(
+                letter_selected < INITIAL_DOT
+                    ? ('A' + letter_selected)
+                    : '.');
 
         if (initial_selected == 0)
             record.initial1 = letter;
@@ -816,12 +932,11 @@ private:
         ++initial_selected;
         save();
 
+        // Like the original OutRun editor, completing three letters does not
+        // remove the ability to correct the last character. Move directly to
+        // END while keeping DELETE immediately adjacent.
         if (initial_selected >= 3)
-        {
-            initials_done = true;
-            ostats.frame_counter = ostats.frame_reset;
-            ostats.time_counter = 3;
-        }
+            letter_selected = INITIAL_END;
     }
 };
 

--- a/src/main/engine/time_trial_records.hpp
+++ b/src/main/engine/time_trial_records.hpp
@@ -481,16 +481,18 @@ private:
 
     void render_records()
     {
-        const uint16_t X_COURSE = 0;
+        // Match the fixed-column approach used by the Endless table. Long
+        // course names and changing digit counts can never move another field.
+        const uint16_t X_COURSE = 1;
         const uint16_t X_NAME = 17;
-        const uint16_t X_TIME = 21;
-        const uint16_t X_OVT = 31;
-        const uint16_t X_CR = 36;
+        const uint16_t X_TIME = 22;
+        const uint16_t X_OVT = 32;
+        const uint16_t X_CR = 37;
 
         ohud.blit_text_new(10, 1, "TIME TRIAL RECORDS", OHud::GREEN);
         ohud.blit_text_new(X_COURSE, 3, "COURSE", OHud::GREY);
         ohud.blit_text_new(X_NAME, 3, "NAME", OHud::GREY);
-        ohud.blit_text_new(X_TIME + 1, 3, "TIME", OHud::GREY);
+        ohud.blit_text_new(X_TIME + 2, 3, "TIME", OHud::GREY);
         ohud.blit_text_new(X_OVT, 3, "OVT", OHud::GREY);
         ohud.blit_text_new(X_CR, 3, "CR", OHud::GREY);
 
@@ -501,11 +503,15 @@ private:
             const uint16_t colour =
                 i == current_track ? OHud::GREEN : OHud::GREY;
 
+            // Clear the entire 40-column row first, exactly like the Endless
+            // table. This prevents stale or longer previous values from making
+            // the columns appear to drift.
             ohud.blit_text_new(
-                X_COURSE,
+                0,
                 y,
-                "                ",
-                colour);
+                "                                        ",
+                OHud::GREY);
+
             ohud.blit_text_new(X_COURSE, y, track_name(i), colour);
 
             if (!record.total_counter)

--- a/src/main/engine/time_trial_records.hpp
+++ b/src/main/engine/time_trial_records.hpp
@@ -714,10 +714,9 @@ private:
         const bool entering_initials = qualifying_score && !initials_done;
 
         // The original alphabet lives at rows 23-24 and its timer at rows 3-4.
-        // While entering initials, use a 15-row scrolling window so neither
-        // original element can cover leaderboard data. Once entry is finished,
-        // restore the normal full 20-entry view.
-        const uint16_t header_y = entering_initials ? 5 : 3;
+        // During initials entry the header stays below the timer; otherwise it
+        // sits one row lower so the centered Traffic class has its own line.
+        const uint16_t header_y = entering_initials ? 5 : 4;
         const uint16_t first_row_y = entering_initials ? 7 : 5;
         const int visible_rows = entering_initials ? 15 : TABLE_ENTRIES;
 
@@ -739,11 +738,7 @@ private:
 
         ohud.blit_text_new(10, 0, "TIME TRIAL RECORDS", OHud::GREEN);
         draw_centered(1, track_name(current_track), OHud::GREEN);
-        ohud.blit_text_new(
-            current_traffic_class == TRAFFIC_ON ? 30 : 29,
-            1,
-            traffic_name(current_traffic_class),
-            OHud::GREEN);
+        draw_centered(2, traffic_name(current_traffic_class), OHud::GREEN);
 
         draw_field(X_POS,   W_POS,   header_y, "#",     OHud::GREY);
         draw_field(X_NAME,  W_NAME,  header_y, "NAME",  OHud::GREY);

--- a/src/main/frontend/config.hpp
+++ b/src/main/frontend/config.hpp
@@ -307,17 +307,41 @@ public:
     void inc_time();
     void inc_traffic();
 
-    // Shared Music Select / Time Trial track-selection timeout switch. Keep it
-    // in the main XML tree so the existing save routine persists it alongside
-    // the other Game Engine settings without needing another config structure.
-    bool selection_timers_enabled()
+    // Shared Music Select / Time Trial selector duration. 0 disables the
+    // automatic selection, otherwise the supported values are 15 or 30 seconds.
+    // The previous ON/OFF implementation stored 1 for ON; treat that legacy
+    // value as the new 30-second default so existing DX configs migrate cleanly.
+    int selection_timer_seconds()
     {
-        return cfg.get_int("engine.selection_timers", 1) != 0;
+        const int value = cfg.get_int("engine.selection_timers", 30);
+        if (value == 1)
+            return 30;
+        if (value == 15 || value == 30)
+            return value;
+        return 0;
     }
 
-    void set_selection_timers_enabled(bool enabled)
+    bool selection_timers_enabled()
     {
-        cfg.put_int("engine.selection_timers", enabled ? 1 : 0);
+        return selection_timer_seconds() != 0;
+    }
+
+    void set_selection_timer_seconds(int seconds)
+    {
+        if (seconds != 15 && seconds != 30)
+            seconds = 0;
+        cfg.put_int("engine.selection_timers", seconds);
+    }
+
+    void cycle_selection_timer()
+    {
+        const int seconds = selection_timer_seconds();
+        if (seconds == 15)
+            set_selection_timer_seconds(30);
+        else if (seconds == 30)
+            set_selection_timer_seconds(0);
+        else
+            set_selection_timer_seconds(15);
     }
 
     // To support multi-threaded SDL module:

--- a/src/main/frontend/config.hpp
+++ b/src/main/frontend/config.hpp
@@ -307,6 +307,19 @@ public:
     void inc_time();
     void inc_traffic();
 
+    // Shared Music Select / Time Trial track-selection timeout switch. Keep it
+    // in the main XML tree so the existing save routine persists it alongside
+    // the other Game Engine settings without needing another config structure.
+    bool selection_timers_enabled()
+    {
+        return cfg.get_int("engine.selection_timers", 1) != 0;
+    }
+
+    void set_selection_timers_enabled(bool enabled)
+    {
+        cfg.put_int("engine.selection_timers", enabled ? 1 : 0);
+    }
+
     // To support multi-threaded SDL module:
     bool videoRestartRequired = false;
 

--- a/src/main/frontend/menu.cpp
+++ b/src/main/frontend/menu.cpp
@@ -50,7 +50,7 @@ namespace
 
     const char* GAMEPAD_RUMBLE_LABEL = "GAMEPAD RUMBLE ";
     const char* PIXEL_SCALER_LABEL = "PIXEL SCALER ";
-    const char* SELECTION_TIMERS_LABEL = "SELECTION TIMERS ";
+    const char* SELECTION_TIMER_LABEL = "SELECTION TIMER ";
 
     bool starts_with_label(const std::string& value, const char* label)
     {
@@ -72,8 +72,9 @@ namespace
 
     std::string selection_timer_menu_text()
     {
-        return std::string(SELECTION_TIMERS_LABEL) +
-            (config.selection_timers_enabled() ? "ON" : "OFF");
+        const int seconds = config.selection_timer_seconds();
+        return std::string(SELECTION_TIMER_LABEL) +
+            (seconds == 0 ? "OFF" : std::to_string(seconds) + " SEC");
     }
 
     const char* ROW_LABELS[BINDING_ROWS] =
@@ -315,10 +316,9 @@ bool Menu::select_pressed()
     {
         const std::string& option = menu_engine[cursor];
 
-        if (starts_with_label(option, SELECTION_TIMERS_LABEL))
+        if (starts_with_label(option, SELECTION_TIMER_LABEL))
         {
-            config.set_selection_timers_enabled(
-                !config.selection_timers_enabled());
+            config.cycle_selection_timer();
             menu_engine[cursor] = selection_timer_menu_text();
             return false;
         }

--- a/src/main/frontend/menu.cpp
+++ b/src/main/frontend/menu.cpp
@@ -50,6 +50,7 @@ namespace
 
     const char* GAMEPAD_RUMBLE_LABEL = "GAMEPAD RUMBLE ";
     const char* PIXEL_SCALER_LABEL = "PIXEL SCALER ";
+    const char* SELECTION_TIMERS_LABEL = "SELECTION TIMERS ";
 
     bool starts_with_label(const std::string& value, const char* label)
     {
@@ -67,6 +68,12 @@ namespace
         return std::string(PIXEL_SCALER_LABEL) +
             pixel_scaler::name(
                 pixel_scaler::mode.load(std::memory_order_relaxed));
+    }
+
+    std::string selection_timer_menu_text()
+    {
+        return std::string(SELECTION_TIMERS_LABEL) +
+            (config.selection_timers_enabled() ? "ON" : "OFF");
     }
 
     const char* ROW_LABELS[BINDING_ROWS] =
@@ -301,6 +308,21 @@ bool Menu::select_pressed()
     const bool pressed = return_pressed || MenuBase::select_pressed();
     if (!pressed)
         return false;
+
+    if (menu_selected == &menu_engine &&
+        cursor >= 0 &&
+        cursor < static_cast<int>(menu_engine.size()))
+    {
+        const std::string& option = menu_engine[cursor];
+
+        if (starts_with_label(option, SELECTION_TIMERS_LABEL))
+        {
+            config.set_selection_timers_enabled(
+                !config.selection_timers_enabled());
+            menu_engine[cursor] = selection_timer_menu_text();
+            return false;
+        }
+    }
 
     if (menu_selected == &menu_enhancements &&
         cursor >= 0 &&

--- a/src/main/frontend/menu.hpp
+++ b/src/main/frontend/menu.hpp
@@ -161,6 +161,22 @@ public:
                 ++it;
         }
 
+        // One shared switch controls the automatic timeout on both selection
+        // screens. Put it directly in Game Engine, immediately before the
+        // existing Enhancements/Car Setup submenus.
+        const std::string selection_timer_entry =
+            std::string("SELECTION TIMERS ") +
+            (config.selection_timers_enabled() ? "ON" : "OFF");
+
+        for (auto it = menu_engine.begin(); it != menu_engine.end(); ++it)
+        {
+            if (it->rfind("ENHANCEMENTS", 0) == 0)
+            {
+                menu_engine.insert(it, selection_timer_entry);
+                break;
+            }
+        }
+
         const int scaler_mode =
             pixel_scaler::mode.load(std::memory_order_relaxed);
         const std::string scaler_entry =

--- a/src/main/frontend/menu.hpp
+++ b/src/main/frontend/menu.hpp
@@ -161,12 +161,15 @@ public:
                 ++it;
         }
 
-        // One shared switch controls the automatic timeout on both selection
-        // screens. Put it directly in Game Engine, immediately before the
-        // existing Enhancements/Car Setup submenus.
+        // One shared duration controls the automatic timeout on both selector
+        // screens. 30 seconds remains the default; 15 seconds and OFF are the
+        // two alternative Game Engine settings.
+        const int selection_seconds = config.selection_timer_seconds();
         const std::string selection_timer_entry =
-            std::string("SELECTION TIMERS ") +
-            (config.selection_timers_enabled() ? "ON" : "OFF");
+            std::string("SELECTION TIMER ") +
+            (selection_seconds == 0
+                ? "OFF"
+                : std::to_string(selection_seconds) + " SEC");
 
         for (auto it = menu_engine.begin(); it != menu_engine.end(); ++it)
         {

--- a/src/main/frontend/ttrial.cpp
+++ b/src/main/frontend/ttrial.cpp
@@ -122,7 +122,7 @@ namespace
         record.initial3 = i3.empty() || i3[0] == '_' ? ' ' : i3[0];
     }
 
-    void load_course_records()
+    void load_course_records(const uint16_t* legacy_best_times)
     {
         for (int mode = 0; mode < 2; mode++)
         {
@@ -167,7 +167,7 @@ namespace
                 fastest_laps[TRAFFIC_ON][track] = static_cast<uint16_t>(
                     data.get_int(
                         "time_trial.score" + Utils::to_string(track),
-                        best_times[track]));
+                        legacy_best_times ? legacy_best_times[track] : 0));
             }
 
             if (!course_records[TRAFFIC_ON][track].total_counter)
@@ -263,7 +263,7 @@ int TTrial::tick()
         case INIT_COURSEMAP:
             outrun.select_course(config.engine.jap != 0, config.engine.prototype != 0);
             config.load_timetrial_scores();
-            load_course_records();
+            load_course_records(best_times);
             ostats.init(true);
             osprites.init();
             video.enabled = true;

--- a/src/main/frontend/ttrial.cpp
+++ b/src/main/frontend/ttrial.cpp
@@ -248,7 +248,10 @@ int TTrial::tick()
                     ostats.credits = 1;
                     return INIT_GAME;
                 }
-                else if (input.has_pressed(Input::LEFT) || oinputs.is_analog_l())
+
+                const int previous_level = level_selected;
+
+                if (input.has_pressed(Input::LEFT) || oinputs.is_analog_l())
                 {
                     if (--level_selected < 0)
                         level_selected = sizeof(FERRARI_POS) - 1;
@@ -258,6 +261,12 @@ int TTrial::tick()
                     if (++level_selected > sizeof(FERRARI_POS) - 1)
                         level_selected = 0;
                 }
+
+                // Give every actual course change a short arcade selection cue.
+                // This follows the same BEEP1 language already used elsewhere
+                // in the DX selection screens and also sounds on wrap-around.
+                if (level_selected != previous_level)
+                    osoundint.queue_sound(sound::BEEP1);
 
                 omap.position_ferrari(FERRARI_POS[level_selected]);
 

--- a/src/main/frontend/ttrial.cpp
+++ b/src/main/frontend/ttrial.cpp
@@ -6,6 +6,7 @@
     See license.txt for more details.
 ***************************************************************************/
 
+#include <SDL.h>
 #include <string>
 
 #include "sdl2/input.hpp"
@@ -49,6 +50,24 @@ namespace
     };
 
     CourseRecordDisplay course_records[15];
+    Uint32 course_select_deadline_ms = 0;
+
+    Uint32 selection_timeout_ms()
+    {
+        // Music Select stores its timeout as two-digit BCD. Reuse exactly that
+        // configured duration so both selection screens behave consistently.
+        const int timer = config.sound.music_timer;
+        const int seconds =
+            (((timer >> 4) & 0x0F) * 10) + (timer & 0x0F);
+
+        return static_cast<Uint32>(seconds > 0 ? seconds : 30) * 1000U;
+    }
+
+    bool course_selection_timed_out()
+    {
+        return course_select_deadline_ms != 0 &&
+            static_cast<Sint32>(SDL_GetTicks() - course_select_deadline_ms) >= 0;
+    }
 
     const char* track_name(int index)
     {
@@ -117,9 +136,9 @@ namespace
 
         // Keep all Time Trial record information on one compact line below
         // the map. The old two-row LAP graphic is intentionally omitted.
-        ohud.blit_text_new(0, 25, "                                        ", OHud::GREY);
-        ohud.blit_text_new(1, 25, "RECORD", OHud::GREY);
-        ohud.blit_text_new(20, 25, "FASTEST LAP", OHud::GREY);
+        ohud.blit_text_new(0, 26, "                                        ", OHud::GREY);
+        ohud.blit_text_new(1, 26, "RECORD", OHud::GREY);
+        ohud.blit_text_new(20, 26, "FASTEST LAP", OHud::GREY);
 
         char initials[4] =
         {
@@ -128,18 +147,18 @@ namespace
             record.initial3 == ' ' ? '-' : record.initial3,
             0
         };
-        ohud.blit_text_new(8, 25, initials, OHud::GREEN);
+        ohud.blit_text_new(8, 26, initials, OHud::GREEN);
 
         if (!record.total_counter)
         {
-            ohud.blit_text_new(12, 25, "NO TIME", OHud::GREEN);
+            ohud.blit_text_new(12, 26, "NO TIME", OHud::GREEN);
             return;
         }
 
         uint8_t converted[3] = {0, 0, 0};
         outils::convert_counter_to_time(record.total_counter, converted);
         ohud.draw_lap_timer(
-            ohud.translate(12, 25),
+            ohud.translate(12, 26),
             converted,
             converted[2]);
     }
@@ -157,6 +176,7 @@ TTrial::~TTrial(void)
 
 void TTrial::init()
 {
+    course_select_deadline_ms = 0;
     state = INIT_COURSEMAP;
 }
 
@@ -184,27 +204,34 @@ int TTrial::tick()
             osoundint.queue_sound(sound::PCM_WAVE);
             outrun.ttrial.laps    = config.ttrial.laps;
             outrun.custom_traffic = config.ttrial.traffic;
+            course_select_deadline_ms = config.selection_timers_enabled()
+                ? SDL_GetTicks() + selection_timeout_ms()
+                : 0;
             state = TICK_COURSEMAP;
 
         case TICK_COURSEMAP:
             {
                 if (input.has_pressed(Input::MENU))
                 {
+                    course_select_deadline_ms = 0;
                     omusic.cancel_time_trial_from_music();
                     return BACK_TO_MENU;
                 }
-                else if (input.has_pressed(Input::LEFT) || oinputs.is_analog_l())
+
+                // Match Music Select: once its configured selection duration
+                // expires, accept whatever is currently highlighted. Check the
+                // deadline before directional input so a held wheel cannot keep
+                // the selector alive indefinitely after timeout.
+                const bool timed_out =
+                    config.selection_timers_enabled() &&
+                    course_selection_timed_out();
+
+                if (timed_out ||
+                    input.has_pressed(Input::START) ||
+                    input.has_pressed(Input::ACCEL) ||
+                    oinputs.is_analog_select())
                 {
-                    if (--level_selected < 0)
-                        level_selected = sizeof(FERRARI_POS) - 1;
-                }
-                else if (input.has_pressed(Input::RIGHT)|| oinputs.is_analog_r())
-                {
-                    if (++level_selected > sizeof(FERRARI_POS) - 1)
-                        level_selected = 0;
-                }
-                else if (input.has_pressed(Input::START) || input.has_pressed(Input::ACCEL) || oinputs.is_analog_select())
-                {
+                    course_select_deadline_ms = 0;
                     outils::convert_counter_to_time(best_times[level_selected], best_converted);
 
                     outrun.cannonball_mode         = Outrun::MODE_TTRIAL;
@@ -222,6 +249,16 @@ int TTrial::tick()
                     ostats.credits = 1;
                     return INIT_GAME;
                 }
+                else if (input.has_pressed(Input::LEFT) || oinputs.is_analog_l())
+                {
+                    if (--level_selected < 0)
+                        level_selected = sizeof(FERRARI_POS) - 1;
+                }
+                else if (input.has_pressed(Input::RIGHT)|| oinputs.is_analog_r())
+                {
+                    if (++level_selected > sizeof(FERRARI_POS) - 1)
+                        level_selected = 0;
+                }
 
                 omap.position_ferrari(FERRARI_POS[level_selected]);
 
@@ -230,7 +267,7 @@ int TTrial::tick()
                 outils::convert_counter_to_time(best_times[level_selected], best_converted);
                 draw_course_record(level_selected);
                 ohud.draw_lap_timer(
-                    ohud.translate(32, 25),
+                    ohud.translate(32, 26),
                     best_converted,
                     best_converted[2]);
 

--- a/src/main/frontend/ttrial.cpp
+++ b/src/main/frontend/ttrial.cpp
@@ -162,8 +162,7 @@ namespace
             // Compatibility with every Time Trial XML written before the
             // multi-entry split. Those records were always the traditional
             // traffic-enabled class, so migrate them into TRAFFIC ON only.
-            if (!fastest_laps[TRAFFIC_ON][track])
-            {
+            if (!fastest_laps[TRAFFIC_ON][track])n            {
                 fastest_laps[TRAFFIC_ON][track] = static_cast<uint16_t>(
                     data.get_int(
                         "time_trial.score" + Utils::to_string(track),
@@ -191,10 +190,14 @@ namespace
         // Prominently identify the course currently selected on the map.
         ohud.blit_text_big(1, track_name(level_selected));
 
-        // Make the Traffic control explicit without involving VIEW2/VIEW3.
-        // The two-line block is right-aligned in the free top-right area.
-        ohud.blit_text_new(30, 3, "PRESS VIEW", OHud::GREY);
-        ohud.blit_text_new(26, 4, "TRAFFIC ON/OFF", OHud::GREEN);
+        // Align the two-line Traffic control with the two-row course title.
+        // The status is live: VIEW toggles between TRAFFIC ON and TRAFFIC OFF.
+        ohud.blit_text_new(30, 1, "PRESS VIEW", OHud::GREY);
+        ohud.blit_text_new(
+            traffic_enabled ? 30 : 29,
+            2,
+            traffic_name(),
+            OHud::GREEN);
 
         // Keep all Time Trial record information on one compact line below
         // the map. The top entry is always from the selected traffic class.

--- a/src/main/frontend/ttrial.cpp
+++ b/src/main/frontend/ttrial.cpp
@@ -162,7 +162,8 @@ namespace
             // Compatibility with every Time Trial XML written before the
             // multi-entry split. Those records were always the traditional
             // traffic-enabled class, so migrate them into TRAFFIC ON only.
-            if (!fastest_laps[TRAFFIC_ON][track])n            {
+            if (!fastest_laps[TRAFFIC_ON][track])
+            {
                 fastest_laps[TRAFFIC_ON][track] = static_cast<uint16_t>(
                     data.get_int(
                         "time_trial.score" + Utils::to_string(track),

--- a/src/main/frontend/ttrial.cpp
+++ b/src/main/frontend/ttrial.cpp
@@ -337,20 +337,15 @@ int TTrial::tick()
                     return INIT_GAME;
                 }
 
-                // A single VIEW button toggles the class. On three-button
-                // cabinets VIEW1 explicitly selects OFF and VIEW3 selects ON,
-                // making the dedicated lamps useful as unambiguous status.
-                const bool traffic_before = traffic_enabled;
-
-                if (input.has_pressed(Input::VIEW1))
-                    traffic_enabled = false;
-                else if (input.has_pressed(Input::VIEW3))
-                    traffic_enabled = true;
-                else if (input.has_pressed(Input::VIEWPOINT))
+                // Both supported cabinet styles use one simple toggle: either
+                // the dedicated VIEW1 button or the classic/general VIEW button.
+                // VIEW2 and VIEW3 remain completely unrelated to Traffic.
+                if (input.has_pressed(Input::VIEW1) ||
+                    input.has_pressed(Input::VIEWPOINT))
+                {
                     traffic_enabled = !traffic_enabled;
-
-                if (traffic_enabled != traffic_before)
                     osoundint.queue_sound(sound::BEEP1);
+                }
 
                 const int previous_level = level_selected;
 

--- a/src/main/frontend/ttrial.cpp
+++ b/src/main/frontend/ttrial.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
     Time Trial Mode Front End.
 
-    This file is part of Cannonball. 
+    This file is part of Cannonball.
     Copyright Chris White.
     See license.txt for more details.
 ***************************************************************************/
@@ -24,13 +24,13 @@
 
 // Track Selection: Ferrari Position Per Track
 // This is a link to a sprite object that represents part of the course map.
-static const uint8_t FERRARI_POS[] = 
+static const uint8_t FERRARI_POS[] =
 {
     1,5,3,11,9,7,19,17,15,13,24,23,22,21,20
 };
 
-// Map Stage Number to Internal Lookup 
-static const uint8_t STAGE_LOOKUP[] = 
+// Map Stage Number to Internal Lookup
+static const uint8_t STAGE_LOOKUP[] =
 {
     0x00,
     0x09, 0x08,
@@ -41,6 +41,9 @@ static const uint8_t STAGE_LOOKUP[] =
 
 namespace
 {
+    const int TRAFFIC_OFF = 0;
+    const int TRAFFIC_ON = 1;
+
     struct CourseRecordDisplay
     {
         uint16_t total_counter = 0;
@@ -49,8 +52,24 @@ namespace
         char initial3 = ' ';
     };
 
-    CourseRecordDisplay course_records[15];
+    CourseRecordDisplay course_records[2][15];
+    uint16_t fastest_laps[2][15] = {};
     Uint32 course_select_deadline_ms = 0;
+
+    // Keep the last chosen traffic class for the next selector visit. The first
+    // visit starts with the traditional Time Trial behaviour: traffic enabled.
+    bool selector_active = false;
+    bool traffic_enabled = true;
+
+    int traffic_class()
+    {
+        return traffic_enabled ? TRAFFIC_ON : TRAFFIC_OFF;
+    }
+
+    const char* traffic_name()
+    {
+        return traffic_enabled ? "TRAFFIC ON" : "TRAFFIC OFF";
+    }
 
     Uint32 selection_timeout_ms()
     {
@@ -87,10 +106,32 @@ namespace
         }
     }
 
+    void read_record(xml_parser::ptree& data,
+                     const std::string& tag,
+                     CourseRecordDisplay& record)
+    {
+        record.total_counter = static_cast<uint16_t>(
+            data.get_int(tag + ".total", 0));
+
+        const std::string i1 = data.get_string(tag + ".initial1", "_");
+        const std::string i2 = data.get_string(tag + ".initial2", "_");
+        const std::string i3 = data.get_string(tag + ".initial3", "_");
+
+        record.initial1 = i1.empty() || i1[0] == '_' ? ' ' : i1[0];
+        record.initial2 = i2.empty() || i2[0] == '_' ? ' ' : i2[0];
+        record.initial3 = i3.empty() || i3[0] == '_' ? ' ' : i3[0];
+    }
+
     void load_course_records()
     {
-        for (CourseRecordDisplay& record : course_records)
-            record = CourseRecordDisplay{};
+        for (int mode = 0; mode < 2; mode++)
+        {
+            for (int track = 0; track < 15; track++)
+            {
+                course_records[mode][track] = CourseRecordDisplay{};
+                fastest_laps[mode][track] = 0;
+            }
+        }
 
         xml_parser::ptree data("timetrial_scores");
         const std::string filename = config.engine.jap ?
@@ -99,22 +140,43 @@ namespace
         if (!xml_parser::read_xml(filename, data))
             return;
 
-        for (int i = 0; i < 15; i++)
+        for (int track = 0; track < 15; track++)
         {
-            const std::string tag =
-                "time_trial.record" + Utils::to_string(i);
+            const std::string track_tag =
+                "time_trial.track" + Utils::to_string(track);
 
-            CourseRecordDisplay& record = course_records[i];
-            record.total_counter = static_cast<uint16_t>(
-                data.get_int(tag + ".total", 0));
+            for (int mode = 0; mode < 2; mode++)
+            {
+                const std::string class_tag = track_tag +
+                    (mode == TRAFFIC_ON ? ".traffic_on" : ".traffic_off");
 
-            const std::string i1 = data.get_string(tag + ".initial1", "_");
-            const std::string i2 = data.get_string(tag + ".initial2", "_");
-            const std::string i3 = data.get_string(tag + ".initial3", "_");
+                fastest_laps[mode][track] = static_cast<uint16_t>(
+                    data.get_int(class_tag + ".fastest_lap", 0));
 
-            record.initial1 = i1.empty() || i1[0] == '_' ? ' ' : i1[0];
-            record.initial2 = i2.empty() || i2[0] == '_' ? ' ' : i2[0];
-            record.initial3 = i3.empty() || i3[0] == '_' ? ' ' : i3[0];
+                read_record(
+                    data,
+                    class_tag + ".entry0",
+                    course_records[mode][track]);
+            }
+
+            // Compatibility with every Time Trial XML written before the
+            // multi-entry split. Those records were always the traditional
+            // traffic-enabled class, so migrate them into TRAFFIC ON only.
+            if (!fastest_laps[TRAFFIC_ON][track])
+            {
+                fastest_laps[TRAFFIC_ON][track] = static_cast<uint16_t>(
+                    data.get_int(
+                        "time_trial.score" + Utils::to_string(track),
+                        best_times[track]));
+            }
+
+            if (!course_records[TRAFFIC_ON][track].total_counter)
+            {
+                read_record(
+                    data,
+                    "time_trial.record" + Utils::to_string(track),
+                    course_records[TRAFFIC_ON][track]);
+            }
         }
     }
 
@@ -123,14 +185,23 @@ namespace
         if (level_selected < 0 || level_selected >= 15)
             return;
 
-        const CourseRecordDisplay& record = course_records[level_selected];
+        const CourseRecordDisplay& record =
+            course_records[traffic_class()][level_selected];
 
         // Prominently identify the course currently selected on the map.
         ohud.blit_text_big(1, track_name(level_selected));
-        ohud.blit_text_new(9, 4, "STEER TO SELECT TRACK", OHud::GREY);
+
+        // The longest course name stops at column 27, leaving a clean status
+        // block in the top-right corner.
+        ohud.blit_text_new(
+            traffic_enabled ? 30 : 29,
+            1,
+            traffic_name(),
+            OHud::GREEN);
+        ohud.blit_text_new(7, 4, "STEER TRACK  VIEW TRAFFIC", OHud::GREY);
 
         // Keep all Time Trial record information on one compact line below
-        // the map. The old two-row LAP graphic is intentionally omitted.
+        // the map. The top entry is always from the selected traffic class.
         ohud.blit_text_new(0, 26, "                                        ", OHud::GREY);
         ohud.blit_text_new(1, 26, "RECORD", OHud::GREY);
         ohud.blit_text_new(20, 26, "FASTEST LAP", OHud::GREY);
@@ -159,6 +230,16 @@ namespace
     }
 }
 
+bool time_trial_selector_active()
+{
+    return selector_active;
+}
+
+bool time_trial_selector_traffic_enabled()
+{
+    return traffic_enabled;
+}
+
 TTrial::TTrial(uint16_t* best_times)
 {
     this->best_times = best_times;
@@ -166,12 +247,12 @@ TTrial::TTrial(uint16_t* best_times)
 
 TTrial::~TTrial(void)
 {
-
 }
 
 void TTrial::init()
 {
     course_select_deadline_ms = 0;
+    selector_active = true;
     state = INIT_COURSEMAP;
 }
 
@@ -180,7 +261,7 @@ int TTrial::tick()
     switch (state)
     {
         case INIT_COURSEMAP:
-            outrun.select_course(config.engine.jap != 0, config.engine.prototype != 0); // Need to setup correct course map graphics.
+            outrun.select_course(config.engine.jap != 0, config.engine.prototype != 0);
             config.load_timetrial_scores();
             load_course_records();
             ostats.init(true);
@@ -190,18 +271,14 @@ int TTrial::tick()
             omap.init();
             omap.load_sprites();
             omap.position_ferrari(FERRARI_POS[level_selected = 0]);
-            // Clear the lower text area previously occupied by the two-row
-            // LAP label and by the earlier stacked Course Record layout.
+
             ohud.blit_text_new(0, 21, "                                        ", OHud::GREY);
             ohud.blit_text_new(0, 23, "                                        ", OHud::GREY);
             ohud.blit_text_new(0, 25, "                                        ", OHud::GREY);
             ohud.blit_text_new(0, 26, "                                        ", OHud::GREY);
             osoundint.queue_sound(sound::PCM_WAVE);
-            outrun.ttrial.laps    = config.ttrial.laps;
-            outrun.custom_traffic = config.ttrial.traffic;
+            outrun.ttrial.laps = config.ttrial.laps;
 
-            // The selector shares the same Game Engine duration as Music
-            // Select: 15 seconds, 30 seconds, or unlimited when set to OFF.
             {
                 const Uint32 timeout_ms = selection_timeout_ms();
                 course_select_deadline_ms = timeout_ms
@@ -209,20 +286,18 @@ int TTrial::tick()
                     : 0;
             }
             state = TICK_COURSEMAP;
+            [[fallthrough]];
 
         case TICK_COURSEMAP:
             {
                 if (input.has_pressed(Input::MENU))
                 {
                     course_select_deadline_ms = 0;
+                    selector_active = false;
                     omusic.cancel_time_trial_from_music();
                     return BACK_TO_MENU;
                 }
 
-                // Match Music Select: once the configured selection duration
-                // expires, accept whatever is currently highlighted. Check the
-                // deadline before directional input so a held wheel cannot keep
-                // the selector alive indefinitely after timeout.
                 const bool timed_out = course_selection_timed_out();
 
                 if (timed_out ||
@@ -231,16 +306,29 @@ int TTrial::tick()
                     oinputs.is_analog_select())
                 {
                     course_select_deadline_ms = 0;
-                    outils::convert_counter_to_time(best_times[level_selected], best_converted);
+                    selector_active = false;
+
+                    const int mode = traffic_class();
+                    const uint16_t selected_best =
+                        fastest_laps[mode][level_selected];
+                    const uint16_t target_counter =
+                        selected_best ? selected_best : 10000;
+                    outils::convert_counter_to_time(
+                        target_counter,
+                        best_converted);
+
+                    const uint8_t selected_traffic = static_cast<uint8_t>(
+                        traffic_enabled ? config.ttrial.traffic : 0);
 
                     outrun.cannonball_mode         = Outrun::MODE_TTRIAL;
                     outrun.ttrial.level            = STAGE_LOOKUP[level_selected];
+                    outrun.ttrial.traffic          = selected_traffic;
+                    outrun.custom_traffic          = selected_traffic;
                     outrun.ttrial.current_lap      = 0;
-                    outrun.ttrial.best_lap_counter = 10000;
+                    outrun.ttrial.best_lap_counter = target_counter;
                     outrun.ttrial.best_lap[0]      = best_converted[0];
                     outrun.ttrial.best_lap[1]      = best_converted[1];
                     outrun.ttrial.best_lap[2]      = best_converted[2];
-                    outrun.ttrial.best_lap_counter = best_times[level_selected];
                     outrun.ttrial.new_high_score   = false;
                     outrun.ttrial.overtakes        = 0;
                     outrun.ttrial.crashes          = 0;
@@ -249,6 +337,21 @@ int TTrial::tick()
                     return INIT_GAME;
                 }
 
+                // A single VIEW button toggles the class. On three-button
+                // cabinets VIEW1 explicitly selects OFF and VIEW3 selects ON,
+                // making the dedicated lamps useful as unambiguous status.
+                const bool traffic_before = traffic_enabled;
+
+                if (input.has_pressed(Input::VIEW1))
+                    traffic_enabled = false;
+                else if (input.has_pressed(Input::VIEW3))
+                    traffic_enabled = true;
+                else if (input.has_pressed(Input::VIEWPOINT))
+                    traffic_enabled = !traffic_enabled;
+
+                if (traffic_enabled != traffic_before)
+                    osoundint.queue_sound(sound::BEEP1);
+
                 const int previous_level = level_selected;
 
                 if (input.has_pressed(Input::LEFT) || oinputs.is_analog_l())
@@ -256,28 +359,37 @@ int TTrial::tick()
                     if (--level_selected < 0)
                         level_selected = sizeof(FERRARI_POS) - 1;
                 }
-                else if (input.has_pressed(Input::RIGHT)|| oinputs.is_analog_r())
+                else if (input.has_pressed(Input::RIGHT) || oinputs.is_analog_r())
                 {
                     if (++level_selected > sizeof(FERRARI_POS) - 1)
                         level_selected = 0;
                 }
 
-                // Give every actual course change a short arcade selection cue.
-                // This follows the same BEEP1 language already used elsewhere
-                // in the DX selection screens and also sounds on wrap-around.
                 if (level_selected != previous_level)
                     osoundint.queue_sound(sound::BEEP1);
 
                 omap.position_ferrari(FERRARI_POS[level_selected]);
 
-                // Course Record total and the existing absolute best single
-                // lap are presented side-by-side on the same bottom row.
-                outils::convert_counter_to_time(best_times[level_selected], best_converted);
+                const int mode = traffic_class();
+                const uint16_t selected_best =
+                    fastest_laps[mode][level_selected];
+
                 draw_course_record(level_selected);
-                ohud.draw_lap_timer(
-                    ohud.translate(32, 26),
-                    best_converted,
-                    best_converted[2]);
+
+                if (selected_best)
+                {
+                    outils::convert_counter_to_time(
+                        selected_best,
+                        best_converted);
+                    ohud.draw_lap_timer(
+                        ohud.translate(32, 26),
+                        best_converted,
+                        best_converted[2]);
+                }
+                else
+                {
+                    ohud.blit_text_new(32, 26, "NO TIME", OHud::GREEN);
+                }
 
                 omap.blit();
                 oroad.tick();
@@ -294,6 +406,11 @@ int TTrial::tick()
 
 void TTrial::update_best_time()
 {
-    best_times[level_selected] = outrun.ttrial.best_lap_counter;
-    config.save_timetrial_scores();
+    // Retain the legacy traffic-enabled best-lap writer for compatibility with
+    // older flows. The DX multi-table path persists both classes itself.
+    if (outrun.ttrial.traffic)
+    {
+        best_times[level_selected] = outrun.ttrial.best_lap_counter;
+        config.save_timetrial_scores();
+    }
 }

--- a/src/main/frontend/ttrial.cpp
+++ b/src/main/frontend/ttrial.cpp
@@ -191,14 +191,10 @@ namespace
         // Prominently identify the course currently selected on the map.
         ohud.blit_text_big(1, track_name(level_selected));
 
-        // The longest course name stops at column 27, leaving a clean status
-        // block in the top-right corner.
-        ohud.blit_text_new(
-            traffic_enabled ? 30 : 29,
-            1,
-            traffic_name(),
-            OHud::GREEN);
-        ohud.blit_text_new(7, 4, "STEER TRACK  VIEW TRAFFIC", OHud::GREY);
+        // Make the Traffic control explicit without involving VIEW2/VIEW3.
+        // The two-line block is right-aligned in the free top-right area.
+        ohud.blit_text_new(30, 3, "PRESS VIEW", OHud::GREY);
+        ohud.blit_text_new(26, 4, "TRAFFIC ON/OFF", OHud::GREEN);
 
         // Keep all Time Trial record information on one compact line below
         // the map. The top entry is always from the selected traffic class.

--- a/src/main/frontend/ttrial.cpp
+++ b/src/main/frontend/ttrial.cpp
@@ -115,27 +115,11 @@ namespace
         ohud.blit_text_big(1, track_name(level_selected));
         ohud.blit_text_new(9, 4, "STEER TO SELECT TRACK", OHud::GREY);
 
-        // The original single-lap record remains at rows 25/26. The new
-        // three-lap record that actually determines the DX Course Record is
-        // displayed directly above it together with the record holder.
-        ohud.blit_text_new(0, 21, "                                        ", OHud::GREY);
-        ohud.blit_text_new(0, 23, "                                        ", OHud::GREY);
-        ohud.blit_text_new(2, 21, "3 LAP RECORD", OHud::GREY);
-        ohud.blit_text_new(2, 23, "RECORD HOLDER", OHud::GREY);
-
-        if (!record.total_counter)
-        {
-            ohud.blit_text_new(18, 21, "NO RECORD", OHud::GREEN);
-            ohud.blit_text_new(18, 23, "---", OHud::GREEN);
-            return;
-        }
-
-        uint8_t converted[3] = {0, 0, 0};
-        outils::convert_counter_to_time(record.total_counter, converted);
-        ohud.draw_lap_timer(
-            ohud.translate(18, 21),
-            converted,
-            converted[2]);
+        // Keep all Time Trial record information on one compact line below
+        // the map. The old two-row LAP graphic is intentionally omitted.
+        ohud.blit_text_new(0, 25, "                                        ", OHud::GREY);
+        ohud.blit_text_new(1, 25, "RECORD", OHud::GREY);
+        ohud.blit_text_new(20, 25, "FASTEST LAP", OHud::GREY);
 
         char initials[4] =
         {
@@ -144,7 +128,20 @@ namespace
             record.initial3 == ' ' ? '-' : record.initial3,
             0
         };
-        ohud.blit_text_new(18, 23, initials, OHud::GREEN);
+        ohud.blit_text_new(8, 25, initials, OHud::GREEN);
+
+        if (!record.total_counter)
+        {
+            ohud.blit_text_new(12, 25, "NO TIME", OHud::GREEN);
+            return;
+        }
+
+        uint8_t converted[3] = {0, 0, 0};
+        outils::convert_counter_to_time(record.total_counter, converted);
+        ohud.draw_lap_timer(
+            ohud.translate(12, 25),
+            converted,
+            converted[2]);
     }
 }
 
@@ -178,8 +175,12 @@ int TTrial::tick()
             omap.init();
             omap.load_sprites();
             omap.position_ferrari(FERRARI_POS[level_selected = 0]);
-            ohud.blit_text1(2, 25, TEXT1_LAPTIME1);
-            ohud.blit_text1(2, 26, TEXT1_LAPTIME2);
+            // Clear the lower text area previously occupied by the two-row
+            // LAP label and by the earlier stacked Course Record layout.
+            ohud.blit_text_new(0, 21, "                                        ", OHud::GREY);
+            ohud.blit_text_new(0, 23, "                                        ", OHud::GREY);
+            ohud.blit_text_new(0, 25, "                                        ", OHud::GREY);
+            ohud.blit_text_new(0, 26, "                                        ", OHud::GREY);
             osoundint.queue_sound(sound::PCM_WAVE);
             outrun.ttrial.laps    = config.ttrial.laps;
             outrun.custom_traffic = config.ttrial.traffic;
@@ -224,15 +225,14 @@ int TTrial::tick()
 
                 omap.position_ferrari(FERRARI_POS[level_selected]);
 
-                // Keep the existing absolute best single lap visible for
-                // reference, but make the new three-lap record and holder the
-                // primary Time Trial target on this screen.
+                // Course Record total and the existing absolute best single
+                // lap are presented side-by-side on the same bottom row.
                 outils::convert_counter_to_time(best_times[level_selected], best_converted);
+                draw_course_record(level_selected);
                 ohud.draw_lap_timer(
-                    ohud.translate(7, 26),
+                    ohud.translate(32, 25),
                     best_converted,
                     best_converted[2]);
-                draw_course_record(level_selected);
 
                 omap.blit();
                 oroad.tick();

--- a/src/main/frontend/ttrial.cpp
+++ b/src/main/frontend/ttrial.cpp
@@ -9,6 +9,7 @@
 #include "sdl2/input.hpp"
 
 #include "frontend/ttrial.hpp"
+#include "../utils.hpp"
 
 #include "engine/ohud.hpp"
 #include "engine/oinputs.hpp"
@@ -35,6 +36,116 @@ static const uint8_t STAGE_LOOKUP[] =
     0x24, 0x23, 0x22, 0x21, 0x20
 };
 
+namespace
+{
+    struct CourseRecordDisplay
+    {
+        uint16_t total_counter = 0;
+        char initial1 = ' ';
+        char initial2 = ' ';
+        char initial3 = ' ';
+    };
+
+    CourseRecordDisplay course_records[15];
+
+    const char* track_name(int index)
+    {
+        switch (index)
+        {
+            case 0:  return "COCONUT BEACH";
+            case 1:  return config.engine.jap ? "WHEAT FIELD" : "GATEWAY";
+            case 2:  return config.engine.jap ? "CLOUDY MOUNTAIN" : "DEVILS CANYON";
+            case 3:  return "DESERT";
+            case 4:  return "ALPS";
+            case 5:  return config.engine.jap ? "DEVILS CANYON" : "CLOUDY MOUNTAIN";
+            case 6:  return "WILDERNESS";
+            case 7:  return "OLD CAPITAL";
+            case 8:  return config.engine.jap ? "GATEWAY" : "WHEAT FIELD";
+            case 9:  return "SEASIDE TOWN";
+            case 10: return "VINEYARD";
+            case 11: return "DEATH VALLEY";
+            case 12: return "DESOLATION HILL";
+            case 13: return "AUTOBAHN";
+            case 14: return "LAKESIDE";
+            default: return "UNKNOWN";
+        }
+    }
+
+    void load_course_records()
+    {
+        for (CourseRecordDisplay& record : course_records)
+            record = CourseRecordDisplay{};
+
+        xml_parser::ptree data("timetrial_scores");
+        const std::string filename = config.engine.jap ?
+            config.data.file_ttrial_jap : config.data.file_ttrial;
+
+        if (!xml_parser::read_xml(filename, data))
+            return;
+
+        for (int i = 0; i < 15; i++)
+        {
+            const std::string tag =
+                "time_trial.record" + Utils::to_string(i);
+
+            CourseRecordDisplay& record = course_records[i];
+            record.total_counter = static_cast<uint16_t>(
+                data.get_int(tag + ".total", 0));
+
+            const std::string i1 = data.get_string(tag + ".initial1", "_");
+            const std::string i2 = data.get_string(tag + ".initial2", "_");
+            const std::string i3 = data.get_string(tag + ".initial3", "_");
+
+            record.initial1 = i1.empty() || i1[0] == '_' ? ' ' : i1[0];
+            record.initial2 = i2.empty() || i2[0] == '_' ? ' ' : i2[0];
+            record.initial3 = i3.empty() || i3[0] == '_' ? ' ' : i3[0];
+        }
+    }
+
+    void draw_course_record(int level_selected)
+    {
+        if (level_selected < 0 || level_selected >= 15)
+            return;
+
+        const CourseRecordDisplay& record = course_records[level_selected];
+
+        // Prominently identify the course currently selected on the map.
+        ohud.blit_text_big(1, track_name(level_selected));
+        ohud.blit_text_new(9, 4, "STEER TO SELECT TRACK", OHud::GREY);
+
+        // The original single-lap record remains at rows 25/26. The new
+        // three-lap record that actually determines the DX Course Record is
+        // displayed directly above it together with the record holder.
+        ohud.blit_text_new(0, 21, "                                        ", OHud::GREY);
+        ohud.blit_text_new(0, 23, "                                        ", OHud::GREY);
+        ohud.blit_text_new(2, 21, "3 LAP RECORD", OHud::GREY);
+        ohud.blit_text_new(2, 23, "RECORD HOLDER", OHud::GREY);
+
+        if (!record.total_counter)
+        {
+            ohud.blit_text_new(18, 21, "NO RECORD", OHud::GREEN);
+            ohud.blit_text_new(18, 23, "---", OHud::GREEN);
+            return;
+        }
+
+        uint8_t converted[3] = {0, 0, 0};
+        outils::convert_counter_to_time(record.total_counter, converted);
+        ohud.draw_lap_timer(
+            ohud.translate(18, 21),
+            converted,
+            converted[2]);
+
+        char initials[4] =
+        {
+            record.initial1 == ' ' ? '-' : record.initial1,
+            record.initial2 == ' ' ? '-' : record.initial2,
+            record.initial3 == ' ' ? '-' : record.initial3,
+            0
+        };
+        ohud.blit_text_new(18, 23, initials, OHud::GREEN);
+    }
+}
+
 TTrial::TTrial(uint16_t* best_times)
 {
     this->best_times = best_times;
@@ -57,6 +168,7 @@ int TTrial::tick()
         case INIT_COURSEMAP:
             outrun.select_course(config.engine.jap != 0, config.engine.prototype != 0); // Need to setup correct course map graphics.
             config.load_timetrial_scores();
+            load_course_records();
             ostats.init(true);
             osprites.init();
             video.enabled = true;
@@ -64,7 +176,6 @@ int TTrial::tick()
             omap.init();
             omap.load_sprites();
             omap.position_ferrari(FERRARI_POS[level_selected = 0]);
-            ohud.blit_text_big(1, "STEER TO SELECT TRACK");
             ohud.blit_text1(2, 25, TEXT1_LAPTIME1);
             ohud.blit_text1(2, 26, TEXT1_LAPTIME2);
             osoundint.queue_sound(sound::PCM_WAVE);
@@ -108,9 +219,19 @@ int TTrial::tick()
                     ostats.credits = 1;
                     return INIT_GAME;
                 }
+
                 omap.position_ferrari(FERRARI_POS[level_selected]);
+
+                // Keep the existing absolute best single lap visible for
+                // reference, but make the new three-lap record and holder the
+                // primary Time Trial target on this screen.
                 outils::convert_counter_to_time(best_times[level_selected], best_converted);
-                ohud.draw_lap_timer(ohud.translate(7, 26), best_converted, best_converted[2]);
+                ohud.draw_lap_timer(
+                    ohud.translate(7, 26),
+                    best_converted,
+                    best_converted[2]);
+                draw_course_record(level_selected);
+
                 omap.blit();
                 oroad.tick();
                 osprites.sprite_copy();

--- a/src/main/frontend/ttrial.cpp
+++ b/src/main/frontend/ttrial.cpp
@@ -54,13 +54,8 @@ namespace
 
     Uint32 selection_timeout_ms()
     {
-        // Music Select stores its timeout as two-digit BCD. Reuse exactly that
-        // configured duration so both selection screens behave consistently.
-        const int timer = config.sound.music_timer;
-        const int seconds =
-            (((timer >> 4) & 0x0F) * 10) + (timer & 0x0F);
-
-        return static_cast<Uint32>(seconds > 0 ? seconds : 30) * 1000U;
+        const int seconds = config.selection_timer_seconds();
+        return seconds > 0 ? static_cast<Uint32>(seconds) * 1000U : 0;
     }
 
     bool course_selection_timed_out()
@@ -204,9 +199,15 @@ int TTrial::tick()
             osoundint.queue_sound(sound::PCM_WAVE);
             outrun.ttrial.laps    = config.ttrial.laps;
             outrun.custom_traffic = config.ttrial.traffic;
-            course_select_deadline_ms = config.selection_timers_enabled()
-                ? SDL_GetTicks() + selection_timeout_ms()
-                : 0;
+
+            // The selector shares the same Game Engine duration as Music
+            // Select: 15 seconds, 30 seconds, or unlimited when set to OFF.
+            {
+                const Uint32 timeout_ms = selection_timeout_ms();
+                course_select_deadline_ms = timeout_ms
+                    ? SDL_GetTicks() + timeout_ms
+                    : 0;
+            }
             state = TICK_COURSEMAP;
 
         case TICK_COURSEMAP:
@@ -218,13 +219,11 @@ int TTrial::tick()
                     return BACK_TO_MENU;
                 }
 
-                // Match Music Select: once its configured selection duration
+                // Match Music Select: once the configured selection duration
                 // expires, accept whatever is currently highlighted. Check the
                 // deadline before directional input so a held wheel cannot keep
                 // the selector alive indefinitely after timeout.
-                const bool timed_out =
-                    config.selection_timers_enabled() &&
-                    course_selection_timed_out();
+                const bool timed_out = course_selection_timed_out();
 
                 if (timed_out ||
                     input.has_pressed(Input::START) ||

--- a/src/main/frontend/ttrial.cpp
+++ b/src/main/frontend/ttrial.cpp
@@ -6,6 +6,8 @@
     See license.txt for more details.
 ***************************************************************************/
 
+#include <string>
+
 #include "sdl2/input.hpp"
 
 #include "frontend/ttrial.hpp"

--- a/src/main/frontend/ttrial.hpp
+++ b/src/main/frontend/ttrial.hpp
@@ -44,9 +44,16 @@ public:
     void update_best_time();
 
 private:
-    // Best lap times for all 15 tracks.
+    // Legacy best-lap table retained for compatibility with older Time Trial
+    // XML files. DX keeps separate ON/OFF fastest-lap values in the same XML.
     uint16_t* best_times;
 
     // Counter converted to actual laptime
     uint8_t best_converted[3];
 };
+
+// Read-only selector state used by cabinet/external-output code. The selector
+// itself remains owned by Menu/TTrial; these helpers avoid coupling the output
+// layer to a particular Menu instance.
+bool time_trial_selector_active();
+bool time_trial_selector_traffic_enabled();


### PR DESCRIPTION
## Time Trial Records

This draft turns Time Trial into a complete arcade-style results and leaderboard flow.

### Finish flow
- Keep the three-lap race and Goal/bonus sequence intact
- Final lap notification also shows the three-lap total and flashes eight times
- Goal celebration is randomized from the available ending sequences
- Show `TIME TRIAL RESULTS` for about seven seconds after Goal
- Results show the driven `TRAFFIC ON` / `TRAFFIC OFF` class centered below the course name
- Traffic OFF results omit overtakes and vehicle collisions, leaving the meaningful crash count
- No visible results countdown
- Automatically transition into the Time Trial leaderboard and then back to attract mode

### Track selector
- Course name and best data are shown for the highlighted track
- Selection timeout uses the shared Game Engine setting: 15 SEC / 30 SEC / OFF
- Traffic can be toggled directly on the selector
- Only `VIEW1` and the classic/general `VIEW` button toggle Traffic; VIEW2/VIEW3 do not
- The top-right selector hint shows `PRESS VIEW` with the live `TRAFFIC ON` or `TRAFFIC OFF` status below it
- Course changes and Traffic changes use a short selection beep
- View/View1 lamp outputs reflect Traffic ON/OFF while the selector is active

### Leaderboards
- Every one of the 15 tracks has its own leaderboard
- Traffic ON and Traffic OFF are completely separate classes
- Each track/class stores up to 20 entries, matching the normal OutRun score-table capacity
- After a run, only the leaderboard for the course and Traffic class just driven is displayed
- The active `TRAFFIC ON` / `TRAFFIC OFF` class is centered directly below the course name
- Traffic ON shows TOTAL, BEST, OVT, COL and CR
- Traffic OFF removes both OVT and vehicle-collision columns and uses the freed space for a full `CRASHES` heading
- A qualifying run is inserted in sorted three-lap-total order and receives normal three-letter initials entry
- Initials entry reuses the original two-row OutRun alphabet, delete arrow, ED graphic and red countdown timer
- The new row is highlighted; first place is a `NEW COURSE RECORD`

### Record rules
- Leaderboard ranking is based on the total time of exactly three laps
- Other configured lap counts can still update their class-specific fastest single lap, but do not enter the three-lap leaderboard
- Fastest single lap is tracked separately for Traffic ON and Traffic OFF

### Persistence
- All tracks, both Traffic classes and all leaderboard positions stay in the existing Time Trial XML (`hiscores_timetrial.xml`, with the existing Japanese equivalent)
- No per-track or per-Traffic score files are created
- Existing legacy `time_trial.score0..14` values and the previous one-record-per-track DX format are migrated into Traffic ON
- Compatibility aliases remain in the XML for older CannonBall Time Trial readers

### Presentation
- Completed laps use the original large TIME HUD graphic with large time digits and a five-flash/beep presentation
- The final lap presentation includes both Lap 3 and TOTAL TIME and flashes eight times
- Traffic OFF hides the complete in-game SCORE label/value, including the previously remaining zero
- Dedicated Time Trial/Endless game-end score screens may rebuild their stable score backdrop, but the normal attract-mode Best OutRunners display preserves the live attract road/background exactly as the original flow does
- Track-select record information remains compact on the bottom row

### Future attract work
The data model is intentionally arranged so a later attract-mode Time Trial overview can show the best time for every course without changing the score-file format again.

### Testing status
Current branch needs another Windows runtime test for the 20-entry per-course tables, Traffic ON/OFF separation, selector controls/lamp outputs, XML migration, initials insertion, no-traffic HUD/results/table suppression, attract Best OutRunners continuity and final-lap presentation.