### PR TITLE
Add merged MAME ZIP ROM loading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,7 +326,6 @@ FetchContent_Declare(
     cannonball_miniz
     GIT_REPOSITORY https://github.com/richgel999/miniz.git
     GIT_TAG 77d0dce8627735138c51770d1799a1ef48f2117d
-    GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(cannonball_miniz)
 target_link_libraries(cannonball-dx PRIVATE miniz)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,6 +314,25 @@ SOURCE_GROUP(src\\engine\\audio FILES ${src_engine_audio})
 
 add_executable(cannonball-dx ${SRCS})
 
+# --- ZIP ROM support -----------------------------------------------------------
+# miniz is used only for reading ROMs directly from ZIP archives. Keep it pinned
+# so Windows, Linux and Raspberry Pi builds all use the same implementation.
+set(BUILD_EXAMPLES OFF CACHE BOOL "Build miniz examples" FORCE)
+set(BUILD_FUZZERS OFF CACHE BOOL "Build miniz fuzzers" FORCE)
+set(BUILD_TESTS OFF CACHE BOOL "Build miniz tests" FORCE)
+set(INSTALL_PROJECT OFF CACHE BOOL "Install miniz" FORCE)
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build miniz as a static library" FORCE)
+FetchContent_Declare(
+    cannonball_miniz
+    GIT_REPOSITORY https://github.com/richgel999/miniz.git
+    GIT_TAG 77d0dce8627735138c51770d1799a1ef48f2117d
+    GIT_SHALLOW TRUE
+)
+FetchContent_MakeAvailable(cannonball_miniz)
+target_link_libraries(cannonball-dx PRIVATE miniz)
+# miniz enables verbose makefiles in its own project; restore CannonBall's choice.
+set(CMAKE_VERBOSE_MAKEFILE OFF CACHE BOOL "Do not echo full compile/link commands" FORCE)
+
 if(WIN32)
     target_compile_features(cannonball-dx PRIVATE cxx_std_23)
     target_compile_definitions(cannonball-dx PRIVATE

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The additional work in this fork was developed with the assistance of **ChatGPT 
 - **Game-mode selection from the Music Select screen** - Original, Continuous or Time Trial via the VIEW controls
 - **Expanded Ferrari colours** - Red, Blue, Yellow, Green, Cyan, Black, White and Silver, with a persistent default colour and per-run Music Select choice
 - **Continuous Mode traffic follows the normal OutRun difficulty and stage scaling**
+- **Direct MAME ROM ZIP loading** with full compatibility for traditional extracted CannonBall ROM sets
 - **Arcade lamp outputs** for START, BRAKE and VIEW lamps via **MAME network output**, **Windows MAMEOutput / MAMEHooker** and the existing **SmartyPi** output path
 
 ---
@@ -66,7 +67,18 @@ The expanded DirectInput force-feedback implementation is primarily intended for
 
 ## ROMs
 
-CannonBall DX requires the original **OutRun revision B** ROM set. Copy the ROMs into the `roms/` directory.
+CannonBall DX requires the original **OutRun Revision B** ROM data. There are now two supported ways to provide it:
+
+- Copy the traditional extracted CannonBall ROM files into `roms/`, exactly as before.
+- Place a suitable MAME ZIP archive such as a current merged `outrun.zip` into `roms/` without extracting it.
+
+ZIP entries are identified by **CRC32 and uncompressed size**, not by archive filename alone. This allows CannonBall DX to locate the Revision B data, the optional alternate early/Japanese program ROMs and corrected PCM data inside modern merged archives even when MAME uses different filenames or subdirectories.
+
+**Backwards compatibility is intentional:** extracted ROMs remain fully supported and take priority when identical data exists both loose and inside a ZIP.
+
+When `sound.fix_samples` is enabled, CannonBall DX prefers Sega/M2's official corrected PCM ROM (`C2DE09B2`), then accepts CannonBall's historical patched `opr-10188.71f` (`37598616`), and finally falls back to the original arcade `opr-10188.71` (`BAD30AD9`). No manual PCM patching is required when the official corrected ROM is present.
+
+See `roms/roms.txt` for the legacy filenames and accepted PCM variants.
 
 You are expected to legally own the original ROMs; usage may be restricted by local law.
 
@@ -81,7 +93,7 @@ chmod +x install.sh
 ./install.sh
 ```
 
-Then copy the OutRun revision B ROMs into `./roms/` and run:
+Then copy either the extracted OutRun Revision B ROMs or a suitable `outrun.zip` into `./roms/` and run:
 
 ```bash
 build/cannonball-dx
@@ -207,6 +219,7 @@ CannonBall DX builds directly on the work of the original projects and their con
 - **Chris White** - creator of the original **CannonBall** engine and core OutRun recreation
 - **James Pearce (J1mbo)** - creator and maintainer of **CannonBall-SE**, including its cabinet, video, performance, audio and gameplay enhancements
 - **Shay Green (Blargg)** - `snes_ntsc` NTSC filter library
+- **Rich Geldreich and miniz contributors** - `miniz` ZIP/DEFLATE library used for direct ROM archive loading
 - **rtissera** - RISC-V RVV 1.0 SIMD support and x86 SSE2 fallback
 - **CannonBall and CannonBall-SE contributors** - fixes, ports, testing and improvements across both upstream projects
 - **Endprodukt** - CannonBall DX fork, multi-device input, ultrawide, cabinet-output and modern wheel / feedback extensions
@@ -223,7 +236,7 @@ Upstream projects:
 
 - **Upstream CannonBall license:** non-commercial use; modified redistributions must include full source; warranty disclaimer. See `license.txt`.
 - **CannonBall-SE additional terms:** SE enhancements © 2020-2025 James Pearce; provided "as is"; not for sale / monetisation; preserve notices. See `CannonBall-SE-license.txt`.
-- **Third-party notices:** includes Blargg's `snes_ntsc` under **LGPL-2.1**. See `THIRD-PARTY-NOTICES.md` and `licenses/`.
+- **Third-party notices:** includes Blargg's `snes_ntsc` under **LGPL-2.1** and `miniz` under its public-domain / Unlicense terms. See `THIRD-PARTY-NOTICES.md` and `licenses/`.
 
 *OutRun is a trademark of SEGA Corporation. This project is not affiliated with SEGA.*
 

--- a/docs/THIRD-PARTY-NOTICES.md
+++ b/docs/THIRD-PARTY-NOTICES.md
@@ -21,3 +21,18 @@ can swap in a compatible modified library. Preserve copyright and license notice
 
 For the full terms, see `licenses/LGPL-2.1.txt`.
 
+---
+
+## miniz
+
+- **Component:** `miniz` 3.1.2
+- **Original author:** Rich Geldreich
+- **License:** Public domain / Unlicense
+- **Upstream:** `richgel999/miniz`
+
+### Notes
+
+CannonBall DX uses miniz for read-only ZIP archive access so OutRun ROMs can be
+loaded directly from MAME ZIP sets. The dependency is fetched at build time from a
+pinned upstream revision. miniz permits unrestricted use under its public-domain /
+Unlicense terms.

--- a/roms/roms.txt
+++ b/roms/roms.txt
@@ -1,6 +1,22 @@
 -------------------------------------------------------------------------------
-Place OutRun Revision B ROMs in this directory.
-They must be named as follows:
+CannonBall DX ROM setup
+-------------------------------------------------------------------------------
+
+CannonBall DX supports both of the following formats:
+
+1. Legacy/extracted ROM files placed directly in this directory.
+2. MAME ZIP archives placed in this directory, including a current merged
+   outrun.zip containing the required OutRun parent/clone ROM data.
+
+ZIP entries are matched by CRC32 and uncompressed size, so the filenames and
+subdirectories used inside a merged MAME archive do not need to match the old
+CannonBall filenames exactly.
+
+Extracted ROM files remain fully supported and take priority over identical
+ROM data found inside ZIP archives.
+
+-------------------------------------------------------------------------------
+OutRun Revision B - legacy extracted filenames
 -------------------------------------------------------------------------------
 epr-10187.88
 epr-10327a.76
@@ -35,13 +51,13 @@ opr-10267.100
 opr-10268.99
 
 -------------------------------------------------------------------------------
-The original Japanese release of OutRun featured slightly different tracks 
-and course ordering.
-
-Optionally, you can include the following files from the Japanese version to
-play these alternate tracks:
+Alternate early/Japanese course data
 -------------------------------------------------------------------------------
+The original Japanese/early OutRun program ROMs used by CannonBall provide
+slightly different tracks and course ordering.
 
+For a legacy extracted setup, optionally include:
+-------------------------------------------------------------------------------
 epr-10380.133
 epr-10382.118
 epr-10381.132
@@ -51,9 +67,26 @@ epr-10329.58
 epr-10328.75
 epr-10330.57
 
--------------------------------------------------------------------------------
-Fixed Audio Rom (Optional)
-http://reassembler.blogspot.co.uk/2013/01/outrun-original-game-shipped-with.html
--------------------------------------------------------------------------------
+A suitable merged MAME outrun.zip may already contain these ROMs; CannonBall DX
+will locate them automatically by CRC32 and size.
 
-opr-10188.71f
+-------------------------------------------------------------------------------
+Corrected PCM sample ROM (optional, recommended)
+-------------------------------------------------------------------------------
+The original opr-10188.71 has the known stuck-data-bit fault. When the fixed
+samples option is enabled, CannonBall DX accepts these in order:
+
+1. Sega/M2 official corrected ROM
+   CRC32: C2DE09B2
+   Current MAME filename: enhanced_203_opr-10188.71
+
+2. Historical CannonBall patched ROM
+   Filename: opr-10188.71f
+   CRC32: 37598616
+
+3. Original faulty arcade ROM as backwards-compatible fallback
+   Filename: opr-10188.71
+   CRC32: BAD30AD9
+
+No manual patch is required when the official corrected ROM is available in a
+ZIP archive or as a loose file.

--- a/roms/roms.txt
+++ b/roms/roms.txt
@@ -2,18 +2,17 @@
 CannonBall DX ROM setup
 -------------------------------------------------------------------------------
 
-CannonBall DX supports both of the following formats:
+Recommended setup:
+Place a current MAME merged outrun.zip in this directory. CannonBall DX reads
+required ROM data directly from the ZIP; no manual extraction is needed.
 
-1. Legacy/extracted ROM files placed directly in this directory.
-2. MAME ZIP archives placed in this directory, including a current merged
-   outrun.zip containing the required OutRun parent/clone ROM data.
+CannonBall DX remains fully backwards-compatible with the traditional setup of
+individual extracted ROM files placed directly in this directory.
 
-ZIP entries are matched by CRC32 and uncompressed size, so the filenames and
-subdirectories used inside a merged MAME archive do not need to match the old
-CannonBall filenames exactly.
-
-Extracted ROM files remain fully supported and take priority over identical
-ROM data found inside ZIP archives.
+ZIP entries are matched by CRC32 and uncompressed size, so filenames and
+subdirectories inside a merged MAME archive do not need to match CannonBall's
+legacy filenames. Extracted ROM files take priority over identical data found
+inside ZIP archives.
 
 -------------------------------------------------------------------------------
 OutRun Revision B - legacy extracted filenames
@@ -24,7 +23,7 @@ epr-10328a.75
 epr-10329a.58
 epr-10330a.57
 epr-10380b.133
-epr-10381a.132
+epr-10381b.132
 epr-10382b.118
 epr-10383b.117
 mpr-10371.9

--- a/src/main/romloader.cpp
+++ b/src/main/romloader.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
-    Binary File Loader. 
-    
+    Binary File Loader.
+
     Handles loading an individual binary file to memory.
     Supports reading bytes, words and longs from this area of memory.
 
@@ -9,6 +9,11 @@
 
     Refactored to remove Boost and Dirent dependency.
     Uses std::filesystem for directory scanning and a small CRC32 impl.
+
+    CannonBall DX adds transparent ZIP archive support while retaining the
+    existing loose-ROM behaviour. ROMs are indexed by CRC32 and uncompressed
+    size, so current MAME merged/split archives and legacy extracted sets can
+    coexist in the same ROM directory.
 ***************************************************************************/
 
 #include <iostream>
@@ -17,6 +22,12 @@
 #include <unordered_map>
 #include <cstdint>
 #include <filesystem>
+#include <vector>
+#include <string>
+#include <algorithm>
+#include <limits>
+
+#include <miniz.h>
 
 #include "stdint.hpp"
 #include "romloader.hpp"
@@ -53,15 +64,212 @@ inline uint32_t crc32(const void* data, std::size_t n)
     return c ^ 0xFFFFFFFFu;
 }
 
-} // namespace
+struct RomKey
+{
+    uint32_t crc;
+    uint32_t size;
 
-static std::unordered_map<int, std::string> map;
-static bool map_created;
+    bool operator==(const RomKey& other) const
+    {
+        return crc == other.crc && size == other.size;
+    }
+};
+
+struct RomKeyHash
+{
+    std::size_t operator()(const RomKey& key) const
+    {
+        return (static_cast<std::size_t>(key.crc) << 1) ^
+               static_cast<std::size_t>(key.size);
+    }
+};
+
+enum class RomSourceType
+{
+    LooseFile,
+    ZipEntry
+};
+
+struct RomSource
+{
+    RomSourceType type = RomSourceType::LooseFile;
+    std::string path;
+    mz_uint file_index = 0;
+    std::string entry_name;
+};
+
+static std::unordered_map<RomKey, RomSource, RomKeyHash> rom_map;
+static bool map_created = false;
+static std::string mapped_rom_path;
+
+bool is_zip_path(const std::filesystem::path& path)
+{
+    std::string ext = path.extension().string();
+    std::transform(ext.begin(), ext.end(), ext.begin(),
+        [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return ext == ".zip";
+}
+
+bool read_entire_file(const std::filesystem::path& path, std::vector<uint8_t>& buffer)
+{
+    namespace fs = std::filesystem;
+
+    std::error_code ec;
+    const uintmax_t file_size = fs::file_size(path, ec);
+    if (ec || file_size > static_cast<uintmax_t>(std::numeric_limits<uint32_t>::max()))
+        return false;
+
+    buffer.resize(static_cast<std::size_t>(file_size));
+
+    std::ifstream src(path, std::ios::in | std::ios::binary);
+    if (!src)
+        return false;
+
+    if (!buffer.empty())
+        src.read(reinterpret_cast<char*>(buffer.data()), static_cast<std::streamsize>(buffer.size()));
+
+    return src.good() || (src.eof() && static_cast<std::size_t>(src.gcount()) == buffer.size());
+}
+
+bool read_exact_file(const std::filesystem::path& path, const int expected_length, std::vector<uint8_t>& buffer)
+{
+    if (expected_length < 0)
+        return false;
+
+    std::error_code ec;
+    const uintmax_t file_size = std::filesystem::file_size(path, ec);
+    if (ec || file_size != static_cast<uintmax_t>(expected_length))
+        return false;
+
+    buffer.resize(static_cast<std::size_t>(expected_length));
+
+    std::ifstream src(path, std::ios::in | std::ios::binary);
+    if (!src)
+        return false;
+
+    if (!buffer.empty())
+        src.read(reinterpret_cast<char*>(buffer.data()), static_cast<std::streamsize>(buffer.size()));
+
+    return static_cast<std::size_t>(src.gcount()) == buffer.size();
+}
+
+void add_loose_file_to_map(const std::filesystem::path& path)
+{
+    std::vector<uint8_t> buffer;
+    if (!read_entire_file(path, buffer))
+        return;
+
+    const RomKey key {
+        crc32(buffer.data(), buffer.size()),
+        static_cast<uint32_t>(buffer.size())
+    };
+
+    // Loose files deliberately win over archives when identical data exists in
+    // both places. This preserves the behaviour expected by existing installs.
+    rom_map.emplace(key, RomSource { RomSourceType::LooseFile, path.string(), 0, std::string() });
+}
+
+void add_zip_to_map(const std::filesystem::path& archive_path)
+{
+    mz_zip_archive zip {};
+    if (!mz_zip_reader_init_file(&zip, archive_path.string().c_str(), 0))
+    {
+        std::cout << "Warning: Could not open ROM archive - " << archive_path.string() << std::endl;
+        return;
+    }
+
+    const mz_uint file_count = mz_zip_reader_get_num_files(&zip);
+    for (mz_uint i = 0; i < file_count; ++i)
+    {
+        mz_zip_archive_file_stat stat {};
+        if (!mz_zip_reader_file_stat(&zip, i, &stat))
+            continue;
+        if (stat.m_is_directory || !stat.m_is_supported || stat.m_is_encrypted)
+            continue;
+        if (stat.m_uncomp_size > static_cast<mz_uint64>(std::numeric_limits<uint32_t>::max()))
+            continue;
+
+        const RomKey key {
+            static_cast<uint32_t>(stat.m_crc32),
+            static_cast<uint32_t>(stat.m_uncomp_size)
+        };
+
+        rom_map.emplace(key, RomSource {
+            RomSourceType::ZipEntry,
+            archive_path.string(),
+            i,
+            stat.m_filename
+        });
+    }
+
+    mz_zip_reader_end(&zip);
+}
+
+bool load_source(const RomSource& source, const int expected_length, std::vector<uint8_t>& buffer, const bool verbose)
+{
+    if (source.type == RomSourceType::LooseFile)
+    {
+        if (!read_exact_file(source.path, expected_length, buffer))
+        {
+            if (verbose)
+                std::cout << "cannot read rom: " << source.path << std::endl;
+            return false;
+        }
+        return true;
+    }
+
+    mz_zip_archive zip {};
+    if (!mz_zip_reader_init_file(&zip, source.path.c_str(), 0))
+    {
+        if (verbose)
+            std::cout << "cannot open rom archive: " << source.path << std::endl;
+        return false;
+    }
+
+    mz_zip_archive_file_stat stat {};
+    if (!mz_zip_reader_file_stat(&zip, source.file_index, &stat) ||
+        stat.m_is_directory || !stat.m_is_supported || stat.m_is_encrypted ||
+        stat.m_uncomp_size != static_cast<mz_uint64>(expected_length))
+    {
+        if (verbose)
+            std::cout << "invalid rom entry in archive: " << source.path
+                      << " -> " << source.entry_name << std::endl;
+        mz_zip_reader_end(&zip);
+        return false;
+    }
+
+    buffer.resize(static_cast<std::size_t>(expected_length));
+    const mz_bool extracted = mz_zip_reader_extract_to_mem(
+        &zip,
+        source.file_index,
+        buffer.data(),
+        buffer.size(),
+        0);
+
+    if (!extracted && verbose)
+    {
+        const mz_zip_error err = mz_zip_get_last_error(&zip);
+        std::cout << "cannot extract rom from archive: " << source.path
+                  << " -> " << source.entry_name
+                  << " (" << mz_zip_get_error_string(err) << ")" << std::endl;
+    }
+
+    mz_zip_reader_end(&zip);
+    return extracted == MZ_TRUE;
+}
+
+void copy_interleaved(uint8_t* destination, const std::vector<uint8_t>& buffer,
+                      const int offset, const uint8_t interleave)
+{
+    for (std::size_t i = 0; i < buffer.size(); ++i)
+        destination[(i * interleave) + static_cast<std::size_t>(offset)] = buffer[i];
+}
+
+} // namespace
 
 RomLoader::RomLoader()
 {
     rom = NULL;
-    map_created = false;
     loaded = false;
 }
 
@@ -86,114 +294,145 @@ void RomLoader::unload(void)
 
 int RomLoader::load_rom(const char* filename, const int offset, const int length, const int expected_crc, const uint8_t interleave, const bool verbose)
 {
-    std::string path = config.data.rom_path;
-    path += std::string(filename);
+    namespace fs = std::filesystem;
 
-    std::ifstream src(path, std::ios::in | std::ios::binary);
-    if (!src)
+    const fs::path base(config.data.rom_path);
+    const fs::path path = base / filename;
+
+    // Preserve the original filename-based loose-ROM behaviour when the file
+    // exists. If it does not, transparently fall back to the CRC index so ZIP
+    // archives also work when data.crc32 is disabled.
+    if (!fs::exists(path))
+        return load_crc32(filename, offset, length, expected_crc, interleave, verbose);
+
+    std::vector<uint8_t> buffer;
+    if (!read_exact_file(path, length, buffer))
     {
-        if (verbose) std::cout << "cannot open rom: " << path << std::endl;
+        if (verbose)
+            std::cout << "cannot read rom or unexpected size: " << path.string() << std::endl;
         loaded = false;
         return 1;
     }
 
-    char* buffer = new char[length];
-    src.read(buffer, length);
-
-    const uint32_t crc = crc32(buffer, static_cast<std::size_t>(src.gcount()));
+    const uint32_t crc = crc32(buffer.data(), buffer.size());
 
     if (expected_crc != static_cast<int>(crc))
     {
         if (verbose)
             std::cout << std::hex
                       << filename << " has incorrect checksum.\nExpected: "
-                      << expected_crc << " Found: " << crc << std::endl;
-
-        delete[] buffer;
-        src.close();
+                      << expected_crc << " Found: " << crc << std::dec << std::endl;
+        loaded = false;
         return 1;
     }
 
-    for (int i = 0; i < length; i++)
-    {
-        rom[(i * interleave) + offset] = buffer[i];
-    }
-
-    delete[] buffer;
-    src.close();
+    copy_interleaved(rom, buffer, offset, interleave);
     loaded = true;
     return 0;
 }
 
 int RomLoader::create_map()
 {
-    map_created = true;
     namespace fs = std::filesystem;
 
-    std::string path = config.data.rom_path;
-    fs::path dir(path);
+    rom_map.clear();
+    mapped_rom_path = config.data.rom_path;
+    map_created = true;
 
-    if (!fs::exists(dir) || !fs::is_directory(dir)) {
-        std::cout << "Warning: Could not open ROM directory - " << path << std::endl;
+    const fs::path source_path(config.data.rom_path);
+
+    // Also accept data.rompath pointing directly at a ZIP file. The normal and
+    // documented form remains a directory such as roms/.
+    if (fs::exists(source_path) && fs::is_regular_file(source_path) && is_zip_path(source_path))
+    {
+        add_zip_to_map(source_path);
+        return rom_map.empty() ? 1 : 0;
+    }
+
+    if (!fs::exists(source_path) || !fs::is_directory(source_path))
+    {
+        std::cout << "Warning: Could not open ROM directory - " << config.data.rom_path << std::endl;
         return 1;
     }
 
-    for (auto& entry : fs::directory_iterator(dir))
+    std::vector<fs::path> archives;
+
+    // First index extracted ROMs. They win ties over identical archive entries
+    // for maximum backwards compatibility with existing CannonBall installs.
+    for (const auto& entry : fs::directory_iterator(source_path))
     {
-        if (!entry.is_regular_file()) continue;
-        std::ifstream src(entry.path(), std::ios::in | std::ios::binary);
-        if (!src) continue;
+        if (!entry.is_regular_file())
+            continue;
 
-        char* buffer = new char[length];
-        src.read(buffer, length);
-        const uint32_t c = crc32(buffer, static_cast<std::size_t>(src.gcount()));
-        map.insert({ static_cast<int>(c), entry.path().string() });
-
-        delete[] buffer;
-        src.close();
+        if (is_zip_path(entry.path()))
+            archives.push_back(entry.path());
+        else
+            add_loose_file_to_map(entry.path());
     }
 
-    if (map.empty())
-        std::cout << "Warning: Could not create CRC32 Map. Did you copy the ROM files into the directory? " << std::endl;
+    // Then index ZIP central directories. No ROM data is decompressed here;
+    // miniz exposes CRC32 and uncompressed size directly from each entry.
+    for (const fs::path& archive : archives)
+        add_zip_to_map(archive);
+
+    if (rom_map.empty())
+    {
+        std::cout << "Warning: Could not create CRC32 ROM map. "
+                  << "Did you copy the ROM files or a MAME ZIP into the directory?" << std::endl;
+        return 1;
+    }
 
     return 0;
 }
 
 int RomLoader::load_crc32(const char* debug, const int offset, const int length, const int expected_crc, const uint8_t interleave, const bool verbose)
 {
-    if (!map_created)
+    if (!map_created || mapped_rom_path != config.data.rom_path)
         create_map();
 
-    if (map.empty())
+    if (rom_map.empty())
         return 1;
 
-    auto search = map.find(expected_crc);
+    const RomKey key {
+        static_cast<uint32_t>(expected_crc),
+        static_cast<uint32_t>(length)
+    };
 
-    if (search == map.end())
+    const auto search = rom_map.find(key);
+
+    if (search == rom_map.end())
     {
-        if (verbose) std::cout << "Unable to locate rom in path: " << config.data.rom_path
-                                << " possible name: " << debug << " crc32: 0x" << std::hex << expected_crc << std::endl;
+        if (verbose)
+            std::cout << "Unable to locate rom in path: " << config.data.rom_path
+                      << " possible name: " << debug
+                      << " crc32: 0x" << std::hex << static_cast<uint32_t>(expected_crc)
+                      << " size: 0x" << length << std::dec << std::endl;
         loaded = false;
         return 1;
     }
 
-    std::string file = search->second;
-    std::ifstream src(file, std::ios::in | std::ios::binary);
-    if (!src)
+    std::vector<uint8_t> buffer;
+    if (!load_source(search->second, length, buffer, verbose))
     {
-        if (verbose) std::cout << "cannot open rom: " << file << std::endl;
         loaded = false;
         return 1;
     }
 
-    char* buffer = new char[length];
-    src.read(buffer, length);
+    // Re-check the uncompressed bytes. ZIP central-directory CRCs are useful
+    // for indexing, but this keeps the same data-integrity guarantee as loose
+    // ROM loading and catches a modified/corrupt archive after indexing.
+    const uint32_t crc = crc32(buffer.data(), buffer.size());
+    if (crc != static_cast<uint32_t>(expected_crc))
+    {
+        if (verbose)
+            std::cout << "ROM checksum changed while loading " << debug
+                      << ". Expected: " << std::hex << static_cast<uint32_t>(expected_crc)
+                      << " Found: " << crc << std::dec << std::endl;
+        loaded = false;
+        return 1;
+    }
 
-    for (int i = 0; i < length; i++)
-        rom[(i * interleave) + offset] = buffer[i];
-
-    delete[] buffer;
-    src.close();
+    copy_interleaved(rom, buffer, offset, interleave);
     loaded = true;
     return 0;
 }
@@ -211,7 +450,7 @@ int RomLoader::load_binary(const char* filename)
     length = filesize(filename);
     char* buffer = new char[length];
     src.read(buffer, length);
-    rom = (uint8_t*) buffer;
+    rom = reinterpret_cast<uint8_t*>(buffer);
     src.close();
     loaded = true;
     return 0;
@@ -221,7 +460,7 @@ int RomLoader::filesize(const char* filename)
 {
     std::ifstream in(filename, std::ifstream::in | std::ifstream::binary);
     in.seekg(0, std::ifstream::end);
-    int size = (int) in.tellg();
+    int size = static_cast<int>(in.tellg());
     in.close();
-    return size; 
+    return size;
 }

--- a/src/main/romloader.cpp
+++ b/src/main/romloader.cpp
@@ -26,6 +26,7 @@
 #include <string>
 #include <algorithm>
 #include <limits>
+#include <cctype>
 
 #include <miniz.h>
 
@@ -316,12 +317,13 @@ int RomLoader::load_rom(const char* filename, const int offset, const int length
 
     const uint32_t crc = crc32(buffer.data(), buffer.size());
 
-    if (expected_crc != static_cast<int>(crc))
+    if (static_cast<uint32_t>(expected_crc) != crc)
     {
         if (verbose)
             std::cout << std::hex
                       << filename << " has incorrect checksum.\nExpected: "
-                      << expected_crc << " Found: " << crc << std::dec << std::endl;
+                      << static_cast<uint32_t>(expected_crc) << " Found: " << crc
+                      << std::dec << std::endl;
         loaded = false;
         return 1;
     }

--- a/src/main/roms.cpp
+++ b/src/main/roms.cpp
@@ -84,7 +84,10 @@ bool Roms::load_revb_roms(bool fixed_rom)
     status += LOAD(pcm, ("opr-10191.68", 0x20000, 0x08000, 0x20a284ab, RomLoader::NORMAL, VERBOSE));
     status += LOAD(pcm, ("opr-10190.69", 0x30000, 0x08000, 0x7cab70e2, RomLoader::NORMAL, VERBOSE));
     status += LOAD(pcm, ("opr-10189.70", 0x40000, 0x08000, 0x01366b54, RomLoader::NORMAL, VERBOSE));
-    status += LOAD(pcm, ("opr-10188.71", 0x50000, 0x08000, 0xbad30ad9, RomLoader::NORMAL, VERBOSE));
+
+    // The final PCM ROM exists in three useful forms. load_pcm_rom() prefers
+    // Sega/M2's official corrected dump, retains CannonBall's historical
+    // patched ROM, and finally falls back to the original faulty arcade dump.
     status += load_pcm_rom(fixed_rom);
 
     // If status has been incremented, a rom has failed to load.
@@ -103,13 +106,13 @@ bool Roms::load_japanese_roms()
     // If incremented, a rom has failed to load.
     jap_rom_status = 0;
 
-    // Load Master CPU ROMs     
+    // Load Master CPU ROMs
     jap_rom_status += LOAD(j_rom0, ("epr-10380.133", 0x00000, 0x10000, 0xe339e87a, RomLoader::INTERLEAVE2, VERBOSE));
     jap_rom_status += LOAD(j_rom0, ("epr-10382.118", 0x00001, 0x10000, 0x65248dd5, RomLoader::INTERLEAVE2, VERBOSE));
     jap_rom_status += LOAD(j_rom0, ("epr-10381.132", 0x20000, 0x10000, 0xbe8c412b, RomLoader::INTERLEAVE2, VERBOSE));
     jap_rom_status += LOAD(j_rom0, ("epr-10383.117", 0x20001, 0x10000, 0xdcc586e7, RomLoader::INTERLEAVE2, VERBOSE));
 
-    // Load Slave CPU ROMs        
+    // Load Slave CPU ROMs
     jap_rom_status += LOAD(j_rom1, ("epr-10327.76", 0x00000, 0x10000, 0xda99d855, RomLoader::INTERLEAVE2, VERBOSE));
     jap_rom_status += LOAD(j_rom1, ("epr-10329.58", 0x00001, 0x10000, 0xfe0fa5e2, RomLoader::INTERLEAVE2, VERBOSE));
     jap_rom_status += LOAD(j_rom1, ("epr-10328.75", 0x20000, 0x10000, 0x3c0e9a7f, RomLoader::INTERLEAVE2, VERBOSE));
@@ -120,25 +123,31 @@ bool Roms::load_japanese_roms()
 
 int Roms::load_pcm_rom(bool fixed_rom)
 {
-    int status = 0;
+    int status = 1;
+
     if (fixed_rom)
     {
-        status = LOAD(pcm, ("opr-10188.71f", 0x50000, 0x08000, 0x37598616, RomLoader::NORMAL, false));
-        if (status == 1)
-            status = LOAD(pcm, ("opr-10188.71f", 0x50000, 0x08000, 0xC2DE09B2, RomLoader::NORMAL, VERBOSE));
+        // Prefer the official Sega/M2 corrected ROM used by current MAME
+        // enhanced sets. CRC matching means it may be named differently or
+        // live inside a merged ZIP archive.
+        status = LOAD(pcm, ("enhanced_203_opr-10188.71", 0x50000, 0x08000, 0xC2DE09B2, RomLoader::NORMAL, false));
 
-        // JJP - soft fail if we don't have the ROM with the fixed samples
-        if (status == 1) {
-            std::cerr << "WARNING: config.fix_samples is set, but patched ROM not found. RevB ROM will be used." << std::endl;
-            fixed_rom = false; // fall through to standard ROM load
+        // Backwards compatibility: CannonBall's historical bspatch output.
+        if (status == 1)
+            status = LOAD(pcm, ("opr-10188.71f", 0x50000, 0x08000, 0x37598616, RomLoader::NORMAL, false));
+
+        if (status == 1)
+        {
+            std::cerr << "WARNING: config.fix_samples is set, but no corrected PCM ROM was found. RevB ROM will be used." << std::endl;
+            fixed_rom = false;
         }
     }
-    if (!fixed_rom)
-    {
-        status = LOAD(pcm, ("opr-10188.71", 0x50000, 0x08000, 0xbad30ad9, RomLoader::NORMAL, VERBOSE));
-    }
 
-    //return LOAD(pcm, (fixed_rom ? "opr-10188.71f" : "opr-10188.71", 0x50000, 0x08000, fixed_rom ? 0x37598616 : 0xbad30ad9, RomLoader::NORMAL)) == 0;
+    // Original OutRun PCM ROM with the known stuck data bit. Keep this as the
+    // final fallback so every legacy extracted Rev B set continues to work.
+    if (!fixed_rom)
+        status = LOAD(pcm, ("opr-10188.71", 0x50000, 0x08000, 0xbad30ad9, RomLoader::NORMAL, VERBOSE));
+
     return status;
 }
 


### PR DESCRIPTION
Adds transparent ROM loading from MAME ZIP archives while keeping legacy extracted ROM files fully supported. Includes corrected PCM ROM preference/fallback handling and updated ROM documentation. Tested successfully with the current ROM ZIP setup.