### PR TITLE
Add Original JP selector and unified high scores

### DIFF
--- a/src/main/engine/omusic.cpp
+++ b/src/main/engine/omusic.cpp
@@ -10,6 +10,7 @@
 #include "main.hpp"
 #include "engine/car_palette_state.hpp"
 #include "engine/oferrari.hpp"
+#include "engine/ohiscore.hpp"
 #include "engine/ohud.hpp"
 #include "engine/oinputs.hpp"
 #include "engine/ologo.hpp"
@@ -22,6 +23,7 @@
 
 #include <SDL.h>
 #include <cstring>
+#include <iostream>
 
 #define enable enable_base
 #define check_start check_start_base
@@ -38,13 +40,16 @@ namespace
     const int CAR_COLOR_COUNT = 8;
     int last_endless_music_stage = -1;
     Uint32 music_select_deadline_ms = 0;
+    bool japanese_selected = false;
 
     enum MusicModeSelection
     {
         SELECT_ORIGINAL = 0,
+        SELECT_ORIGINAL_JP,
         SELECT_CONTINUOUS,
         SELECT_ENDLESS,
         SELECT_TIME_TRIAL,
+        SELECT_COUNT,
     };
 
     int wrap_car_color(int color)
@@ -62,16 +67,44 @@ namespace
             static_cast<Sint32>(SDL_GetTicks() - music_select_deadline_ms) >= 0;
     }
 
-    void draw_endless_mode_name()
+    bool apply_course_variant(bool japanese)
     {
-        const char* text = "ENDLESS";
+        // Music Select changes modes after Outrun::init() has already run, so
+        // the normal STATE_INIT_GAME ROM-loading path cannot switch regions for
+        // us. Lazily load the Japanese program ROMs here and remap the complete
+        // address/course table before the new race is initialized.
+        if (japanese && !roms.load_japanese_roms())
+        {
+            std::cerr
+                << "Japanese ROMs not loaded. Falling back to Original."
+                << std::endl;
+            japanese = false;
+        }
+
+        config.engine.jap = japanese ? 1 : 0;
+        outrun.select_course(japanese, config.engine.prototype != 0);
+
+        // Each course variant owns a separate score file. When switching from
+        // World to Japanese (or back) after boot(), the previous table is still
+        // resident in memory. Reset it first so a missing target score file
+        // starts from the factory defaults instead of inheriting the other
+        // region's entries. An existing score file is loaded over these defaults
+        // immediately afterwards by the normal Music Select start path.
+        ohiscore.init_def_scores();
+
+        return japanese;
+    }
+
+    void draw_submode_name(const char* text)
+    {
         const uint8_t y = 5;
         const uint16_t pal = 0x8AA0;
         const int length = static_cast<int>(std::strlen(text));
         const int x_start = 20 - (length / 2);
 
-        // The preserved selector renders MODE_CONT as CONTINUOUS. Replace only
-        // those two text rows when the VIEW2 sub-mode is Endless.
+        // The preserved selector only knows the three underlying engine modes.
+        // Replace those two text rows for DX sub-modes that intentionally share
+        // MODE_ORIGINAL or MODE_CONT.
         for (int x = 0; x < 40; x++)
         {
             video.write_text16(ohud.translate(x, y), 0);
@@ -82,9 +115,18 @@ namespace
         for (int i = 0; i < length; i++)
         {
             uint16_t c = static_cast<uint8_t>(text[i]);
-            c = ((c - 'A') * 2) + pal;
-            video.write_text16(&dst_addr, c);
-            video.write_text16(0x7E + dst_addr, c + 1);
+
+            if (c == ' ')
+            {
+                video.write_text16(&dst_addr, 0);
+                video.write_text16(0x7E + dst_addr, 0);
+            }
+            else if (c >= 'A' && c <= 'Z')
+            {
+                c = ((c - 'A') * 2) + pal;
+                video.write_text16(&dst_addr, c);
+                video.write_text16(0x7E + dst_addr, c + 1);
+            }
         }
     }
 }
@@ -122,8 +164,12 @@ void OMusic::enable()
         ostats.frame_counter = ostats.frame_reset;
     }
 
-    // Endless deliberately shares MODE_CONT. Restore its second VIEW2 state
-    // when returning to Music Select after an Endless run.
+    // VIEW1 and VIEW2 each have a second selector state while still sharing
+    // their original CannonBall engine modes underneath.
+    japanese_selected =
+        outrun.cannonball_mode == Outrun::MODE_ORIGINAL &&
+        config.engine.jap != 0;
+
     endless_selected =
         outrun.cannonball_mode == Outrun::MODE_CONT && outrun.endless_mode;
 
@@ -137,21 +183,26 @@ void OMusic::check_start()
     int old_color = wrap_car_color(config.engine.car_pal);
     int color_direction = 0;
 
-    // Resolve the four logical choices while keeping only the three existing
-    // CannonBall engine modes underneath. VIEW cycles all four. VIEW2 toggles
-    // Continuous <-> Endless when it is pressed repeatedly.
+    // Resolve the five logical choices while keeping only the three existing
+    // CannonBall engine modes underneath. VIEW1 toggles Original <-> Original
+    // JP, VIEW2 toggles Continuous <-> Endless, and VIEW cycles all five.
     int old_selection = SELECT_ORIGINAL;
     if (game_mode_selected == Outrun::MODE_TTRIAL)
         old_selection = SELECT_TIME_TRIAL;
     else if (game_mode_selected == Outrun::MODE_CONT)
         old_selection = endless_selected ? SELECT_ENDLESS : SELECT_CONTINUOUS;
+    else if (japanese_selected)
+        old_selection = SELECT_ORIGINAL_JP;
 
     int new_selection = old_selection;
     bool mode_pressed = false;
 
     if (input.has_pressed(Input::VIEW1))
     {
-        new_selection = SELECT_ORIGINAL;
+        new_selection =
+            old_selection == SELECT_ORIGINAL ? SELECT_ORIGINAL_JP :
+            old_selection == SELECT_ORIGINAL_JP ? SELECT_ORIGINAL :
+            SELECT_ORIGINAL;
         mode_pressed = true;
     }
     else if (input.has_pressed(Input::VIEW2))
@@ -169,7 +220,7 @@ void OMusic::check_start()
     }
     else if (input.has_pressed(Input::VIEWPOINT))
     {
-        new_selection = (old_selection + 1) & 3;
+        new_selection = (old_selection + 1) % SELECT_COUNT;
         mode_pressed = true;
     }
 
@@ -177,6 +228,8 @@ void OMusic::check_start()
         ostats.credits && input.has_pressed(Input::START);
     const bool starting_endless =
         start_pressed && old_selection == SELECT_ENDLESS;
+    bool starting_japanese =
+        start_pressed && old_selection == SELECT_ORIGINAL_JP;
 
     // Endless is a survival mode, so the global Timer OFF option must never
     // freeze its countdown. Restore the normal user setting for Original and
@@ -184,6 +237,11 @@ void OMusic::check_start()
     if (start_pressed)
     {
         music_select_deadline_ms = 0;
+
+        // Commit the selected region before check_start_base() saves config and
+        // refreshes the score table. Non-JP modes explicitly restore World data.
+        starting_japanese = apply_course_variant(starting_japanese);
+        japanese_selected = starting_japanese;
 
         if (old_selection == SELECT_ENDLESS)
             outrun.freeze_timer = false;
@@ -230,30 +288,40 @@ void OMusic::check_start()
     check_start_base();
 
     // The preserved selector knows Original / Continuous / Time Trial. Apply
-    // the fourth logical state after its input handling. A VIEW press and START
+    // the two DX sub-mode states after its input handling. A VIEW press and START
     // on exactly the same frame remains intentionally undefined; normal arcade
     // use selects the mode first and confirms it afterwards.
     if (mode_pressed)
     {
         switch (new_selection)
         {
+            case SELECT_ORIGINAL_JP:
+                game_mode_selected = Outrun::MODE_ORIGINAL;
+                japanese_selected = true;
+                endless_selected = false;
+                break;
+
             case SELECT_CONTINUOUS:
                 game_mode_selected = Outrun::MODE_CONT;
+                japanese_selected = false;
                 endless_selected = false;
                 break;
 
             case SELECT_ENDLESS:
                 game_mode_selected = Outrun::MODE_CONT;
+                japanese_selected = false;
                 endless_selected = true;
                 break;
 
             case SELECT_TIME_TRIAL:
                 game_mode_selected = Outrun::MODE_TTRIAL;
+                japanese_selected = false;
                 endless_selected = false;
                 break;
 
             default:
                 game_mode_selected = Outrun::MODE_ORIGINAL;
+                japanese_selected = false;
                 endless_selected = false;
                 break;
         }
@@ -315,6 +383,12 @@ void OMusic::tick()
         music_selection_timed_out())
     {
         music_select_deadline_ms = 0;
+
+        bool starting_japanese =
+            game_mode_selected == Outrun::MODE_ORIGINAL && japanese_selected;
+        starting_japanese = apply_course_variant(starting_japanese);
+        japanese_selected = starting_japanese;
+
         config.save();
 
         if (game_mode_selected == Outrun::MODE_TTRIAL &&
@@ -387,10 +461,11 @@ void OMusic::tick()
         ostats.frame_counter = ostats.frame_reset;
     }
 
-    if (outrun.game_state == GS_MUSIC &&
-        game_mode_selected == Outrun::MODE_CONT &&
-        endless_selected)
+    if (outrun.game_state == GS_MUSIC)
     {
-        draw_endless_mode_name();
+        if (game_mode_selected == Outrun::MODE_ORIGINAL && japanese_selected)
+            draw_submode_name("ORIGINAL JP");
+        else if (game_mode_selected == Outrun::MODE_CONT && endless_selected)
+            draw_submode_name("ENDLESS");
     }
 }

--- a/src/main/engine/omusic.cpp
+++ b/src/main/engine/omusic.cpp
@@ -95,6 +95,17 @@ namespace
         return japanese;
     }
 
+    void save_config_with_world_default()
+    {
+        // ORIGINAL JP is a per-run Music Select choice, not a persistent boot
+        // preference. Preserve the live Japanese mapping for the race while
+        // always writing World/ORIGINAL as the saved default for the next run.
+        const int runtime_jap = config.engine.jap;
+        config.engine.jap = 0;
+        config.save();
+        config.engine.jap = runtime_jap;
+    }
+
     void draw_submode_name(const char* text)
     {
         const uint8_t y = 5;
@@ -164,11 +175,10 @@ void OMusic::enable()
         ostats.frame_counter = ostats.frame_reset;
     }
 
-    // VIEW1 and VIEW2 each have a second selector state while still sharing
-    // their original CannonBall engine modes underneath.
-    japanese_selected =
-        outrun.cannonball_mode == Outrun::MODE_ORIGINAL &&
-        config.engine.jap != 0;
+    // ORIGINAL JP is deliberately never sticky. If the underlying engine mode
+    // is Original, every fresh selector visit begins at World/ORIGINAL and the
+    // player must press VIEW1 again to opt into JP for this run.
+    japanese_selected = false;
 
     endless_selected =
         outrun.cannonball_mode == Outrun::MODE_CONT && outrun.endless_mode;
@@ -287,6 +297,12 @@ void OMusic::check_start()
 
     check_start_base();
 
+    // The preserved start path may save config while the live JP mapping is
+    // active. Immediately rewrite the persistent setting as World/ORIGINAL;
+    // save_config_with_world_default() restores the live JP flag afterwards.
+    if (start_pressed)
+        save_config_with_world_default();
+
     // The preserved selector knows Original / Continuous / Time Trial. Apply
     // the two DX sub-mode states after its input handling. A VIEW press and START
     // on exactly the same frame remains intentionally undefined; normal arcade
@@ -346,10 +362,10 @@ void OMusic::check_start()
             wrap_car_color(old_color + color_direction);
 
         // The preserved five-colour routine may already have saved on START.
-        // Config::save() now always persists the separate attract/default
-        // colour, so this correction remains race-only even on the START frame.
+        // Keep the region persistence rule intact while applying the corrected
+        // eight-colour race-only value.
         if (save_after_correction)
-            config.save();
+            save_config_with_world_default();
     }
 }
 
@@ -389,7 +405,7 @@ void OMusic::tick()
         starting_japanese = apply_course_variant(starting_japanese);
         japanese_selected = starting_japanese;
 
-        config.save();
+        save_config_with_world_default();
 
         if (game_mode_selected == Outrun::MODE_TTRIAL &&
             outrun.cannonball_mode != Outrun::MODE_TTRIAL)

--- a/src/main/frontend/config.cpp
+++ b/src/main/frontend/config.cpp
@@ -428,6 +428,12 @@ void Config::load()
     if (first_run || cfg.get_int("controls.keyconfig.menu", -1) == -1)
         controls.keyconfig[10] = SDLK_F5;
 
+    // CannonBall DX stores every score table in one physical file. Keep the
+    // old mode-specific paths as logical selectors, but make Original World
+    // point at the real file so the legacy Clear Scores action removes it too.
+    data.file_scores = data.save_path + "highscores.xml";
+    xml_parser::migrate_highscores(data.save_path);
+
     // Do not inherit historical CannonBall-SE CRT/filter defaults on first run.
     // This deliberately overrides both the hard-coded config_base fallbacks and
     // an outdated res/config.xml that may still be present in a build folder.

--- a/src/main/frontend/config.hpp
+++ b/src/main/frontend/config.hpp
@@ -15,7 +15,7 @@
 #include <string>
 #include <vector>
 #include "stdint.hpp"
-#include "xml_parser.h" // replaces Boost for XML handling
+#include "highscore_storage.hpp" // one physical highscores.xml for all score tables
 
 struct data_settings_t
 {

--- a/src/main/frontend/highscore_storage.hpp
+++ b/src/main/frontend/highscore_storage.hpp
@@ -7,6 +7,12 @@
     storing every high-score table inside one physical highscores.xml file.
     Legacy hiscores*.xml files are imported once and removed only after the
     combined file has been written successfully.
+
+    Physical sections:
+      original_world / original_japan
+      continuous_world / continuous_japan
+      time_trial_world / time_trial_japan
+      endless_world / endless_japan
 ***************************************************************************/
 
 // Rename the low-level XML functions while including the existing TinyXML2

--- a/src/main/frontend/highscore_storage.hpp
+++ b/src/main/frontend/highscore_storage.hpp
@@ -1,0 +1,267 @@
+#pragma once
+
+/***************************************************************************
+    CannonBall DX Unified High-Score Storage
+
+    Keep the existing score systems and their logical filenames intact while
+    storing every high-score table inside one physical highscores.xml file.
+    Legacy hiscores*.xml files are imported once and removed only after the
+    combined file has been written successfully.
+***************************************************************************/
+
+// Rename the low-level XML functions while including the existing TinyXML2
+// wrapper. Callers that include config.hpp will use the routed functions below;
+// the raw functions remain available here for physical file I/O.
+#define read_xml read_xml_raw
+#define write_xml write_xml_raw
+#include "xml_parser.h"
+#undef write_xml
+#undef read_xml
+
+#include <array>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace xml_parser
+{
+namespace highscore_storage_detail
+{
+    struct ScoreSlot
+    {
+        const char* logical_filename;
+        const char* section;
+    };
+
+    // highscores.xml itself is the live logical path for Original World. The
+    // remaining legacy-looking names are virtual selectors after migration.
+    static constexpr std::array<ScoreSlot, 9> SCORE_SLOTS = {{
+        { "highscores.xml",                 "original_world" },
+        { "hiscores.xml",                   "original_world" },
+        { "hiscores_jap.xml",               "original_japan" },
+        { "hiscores_continuous.xml",        "continuous_world" },
+        { "hiscores_continuous_jap.xml",    "continuous_japan" },
+        { "hiscores_timetrial.xml",         "time_trial_world" },
+        { "hiscores_timetrial_jap.xml",     "time_trial_japan" },
+        { "hiscores_endless.xml",           "endless_world" },
+        { "hiscores_endless_jap.xml",       "endless_japan" },
+    }};
+
+    static constexpr std::array<ScoreSlot, 8> LEGACY_FILES = {{
+        { "hiscores.xml",                   "original_world" },
+        { "hiscores_jap.xml",               "original_japan" },
+        { "hiscores_continuous.xml",        "continuous_world" },
+        { "hiscores_continuous_jap.xml",    "continuous_japan" },
+        { "hiscores_timetrial.xml",         "time_trial_world" },
+        { "hiscores_timetrial_jap.xml",     "time_trial_japan" },
+        { "hiscores_endless.xml",           "endless_world" },
+        { "hiscores_endless_jap.xml",       "endless_japan" },
+    }};
+
+    inline std::string basename(const std::string& path)
+    {
+        const std::size_t pos = path.find_last_of("/\\");
+        return pos == std::string::npos ? path : path.substr(pos + 1);
+    }
+
+    inline std::string directory(const std::string& path)
+    {
+        const std::size_t pos = path.find_last_of("/\\");
+        return pos == std::string::npos ? std::string() : path.substr(0, pos + 1);
+    }
+
+    inline const ScoreSlot* slot_for_path(const std::string& path)
+    {
+        const std::string name = basename(path);
+        for (const ScoreSlot& slot : SCORE_SLOTS)
+        {
+            if (name == slot.logical_filename)
+                return &slot;
+        }
+        return nullptr;
+    }
+
+    inline std::string unified_path_for(const std::string& logical_path)
+    {
+        return directory(logical_path) + "highscores.xml";
+    }
+
+    inline void reset_tree(ptree& tree, const char* root_name)
+    {
+        tree.doc.Clear();
+        tree.root = tree.doc.NewElement(root_name);
+        tree.doc.InsertFirstChild(tree.root);
+    }
+
+    inline bool is_unified_tree(const ptree& tree)
+    {
+        return tree.root &&
+               std::strcmp(tree.root->Name(), "highscores") == 0;
+    }
+
+    inline bool load_unified(const std::string& path, ptree& tree)
+    {
+        if (!read_xml_raw(path, tree, parse_mode_t::strict) ||
+            !is_unified_tree(tree))
+        {
+            reset_tree(tree, "highscores");
+            return false;
+        }
+        return true;
+    }
+
+    inline tinyxml2::XMLElement* section_root(
+        ptree& tree,
+        const char* section)
+    {
+        tinyxml2::XMLElement* container =
+            tree.root ? tree.root->FirstChildElement(section) : nullptr;
+        return container ? container->FirstChildElement() : nullptr;
+    }
+
+    inline void replace_section(
+        ptree& combined,
+        const char* section_name,
+        const tinyxml2::XMLElement* source_root)
+    {
+        if (!combined.root || !source_root)
+            return;
+
+        if (tinyxml2::XMLElement* old =
+                combined.root->FirstChildElement(section_name))
+        {
+            combined.root->DeleteChild(old);
+        }
+
+        tinyxml2::XMLElement* section =
+            combined.doc.NewElement(section_name);
+        section->InsertEndChild(source_root->DeepClone(&combined.doc));
+        combined.root->InsertEndChild(section);
+    }
+
+    inline bool migrate_legacy_files(const std::string& unified_path)
+    {
+        ptree combined("highscores");
+        bool unified_valid = load_unified(unified_path, combined);
+        bool changed = false;
+        std::vector<std::string> cleanup;
+        const std::string dir = directory(unified_path);
+
+        for (const ScoreSlot& legacy_slot : LEGACY_FILES)
+        {
+            const std::string legacy_path =
+                dir + legacy_slot.logical_filename;
+
+            ptree legacy("scores");
+            if (!read_xml_raw(legacy_path, legacy))
+                continue;
+
+            // An existing unified section wins. This makes migration idempotent
+            // and prevents a stale legacy file from overwriting newer DX data.
+            if (!section_root(combined, legacy_slot.section) && legacy.root)
+            {
+                replace_section(combined, legacy_slot.section, legacy.root);
+                changed = true;
+            }
+
+            cleanup.push_back(legacy_path);
+        }
+
+        if (changed)
+        {
+            if (!write_xml_raw(unified_path, combined))
+                return unified_valid;
+            unified_valid = true;
+        }
+
+        // Never delete source files unless a valid combined file exists.
+        if (unified_valid)
+        {
+            for (const std::string& path : cleanup)
+                std::remove(path.c_str());
+        }
+
+        return unified_valid;
+    }
+
+    inline bool copy_section_to_tree(
+        ptree& combined,
+        const char* section,
+        ptree& destination)
+    {
+        tinyxml2::XMLElement* source = section_root(combined, section);
+        if (!source)
+            return false;
+
+        destination.doc.Clear();
+        tinyxml2::XMLNode* clone = source->DeepClone(&destination.doc);
+        destination.doc.InsertFirstChild(clone);
+        destination.root = clone->ToElement();
+        return destination.root != nullptr;
+    }
+}
+
+// Public one-shot migration hook used during Config::load(). It also makes the
+// old files disappear immediately rather than waiting for a specific mode to
+// touch its score table.
+inline bool migrate_highscores(const std::string& save_path)
+{
+    return highscore_storage_detail::migrate_legacy_files(
+        save_path + "highscores.xml");
+}
+
+inline bool read_xml(const std::string& filename,
+                     ptree& tree,
+                     parse_mode_t mode = parse_mode)
+{
+    using namespace highscore_storage_detail;
+
+    const ScoreSlot* slot = slot_for_path(filename);
+    if (!slot)
+        return read_xml_raw(filename, tree, mode);
+
+    const std::string unified_path = unified_path_for(filename);
+    migrate_legacy_files(unified_path);
+
+    ptree combined("highscores");
+    if (!load_unified(unified_path, combined))
+        return false;
+
+    return copy_section_to_tree(combined, slot->section, tree);
+}
+
+inline bool write_xml(
+    const std::string& filename,
+    ptree& tree,
+    const std::string& xml_declaration =
+        R"(<?xml version="1.0" encoding="UTF-8"?>)")
+{
+    using namespace highscore_storage_detail;
+
+    const ScoreSlot* slot = slot_for_path(filename);
+    if (!slot)
+        return write_xml_raw(filename, tree, xml_declaration);
+
+    if (!tree.root)
+        return false;
+
+    const std::string unified_path = unified_path_for(filename);
+    migrate_legacy_files(unified_path);
+
+    ptree combined("highscores");
+    load_unified(unified_path, combined);
+    replace_section(combined, slot->section, tree.root);
+
+    if (!write_xml_raw(unified_path, combined, xml_declaration))
+        return false;
+
+    // A logical legacy filename is only a selector now. Remove a stale physical
+    // copy if one still exists after a successful combined write.
+    if (basename(filename) != "highscores.xml")
+        std::remove(filename.c_str());
+
+    return true;
+}
+
+} // namespace xml_parser

--- a/src/main/frontend/highscore_storage.hpp
+++ b/src/main/frontend/highscore_storage.hpp
@@ -102,7 +102,7 @@ namespace highscore_storage_detail
 
     inline bool is_unified_tree(const ptree& tree)
     {
-        return tree.root &&
+        return tree.root && tree.root->Name() &&
                std::strcmp(tree.root->Name(), "highscores") == 0;
     }
 
@@ -202,6 +202,9 @@ namespace highscore_storage_detail
 
         destination.doc.Clear();
         tinyxml2::XMLNode* clone = source->DeepClone(&destination.doc);
+        if (!clone)
+            return false;
+
         destination.doc.InsertFirstChild(clone);
         destination.root = clone->ToElement();
         return destination.root != nullptr;


### PR DESCRIPTION
Adds a second VIEW1 state on the Music Select screen and consolidates all high-score tables into one physical file.

Original JP:
- ORIGINAL -> ORIGINAL JP -> ORIGINAL on repeated VIEW1 presses
- VIEW cycles ORIGINAL -> ORIGINAL JP -> CONTINUOUS -> ENDLESS -> TIME TRIAL
- ORIGINAL JP reuses MODE_ORIGINAL and the existing VIEW1 output/lamp
- Japanese ROMs are loaded lazily when the selection is committed
- Japanese ROM/address/course mapping and Japanese high scores are selected together
- Non-JP modes explicitly restore the World course mapping
- Missing Japanese program ROMs fall back to normal ORIGINAL instead of quitting

Unified high scores:
- All score tables are stored in one `highscores.xml`
- Separate sections are retained for Original World/JP, Continuous World/JP, Time Trial World/JP and Endless World/JP
- Existing `hiscores*.xml` files are migrated automatically at startup
- Legacy score files are deleted only after `highscores.xml` has been written successfully
- `play_stats.xml` remains separate because it contains machine statistics, not high scores
- The existing Clear Scores action removes the unified file