### PR TITLE
Fix mirrored Ferrari badge and number plate

### DIFF
--- a/src/main/frontend/config.hpp
+++ b/src/main/frontend/config.hpp
@@ -2,8 +2,8 @@
     XML Configuration File Handling - CannonBall DX extensions.
 
     The current configuration declaration is preserved in config_base.hpp.
-    This wrapper adds the persistent five-step bumper-view height setting
-    without duplicating the inherited configuration structure.
+    This wrapper adds DX-only persistent settings without duplicating the
+    inherited configuration structure.
 ***************************************************************************/
 
 #pragma once
@@ -38,6 +38,18 @@
     { \
         set_bumper_view_height_level( \
             (bumper_view_height_level() + 1) % BUMPER_VIEW_HEIGHT_LEVELS); \
+    } \
+    bool ferrari_mirror_fix() \
+    { \
+        return cfg.get_int("engine.ferrari_mirror_fix", 1) != 0; \
+    } \
+    void set_ferrari_mirror_fix(bool enabled) \
+    { \
+        cfg.put_int("engine.ferrari_mirror_fix", enabled ? 1 : 0); \
+    } \
+    void toggle_ferrari_mirror_fix() \
+    { \
+        set_ferrari_mirror_fix(!ferrari_mirror_fix()); \
     }
 
 #define private public: CANNONBALL_DX_CONFIG_EXTENSIONS private

--- a/src/main/frontend/menu.cpp
+++ b/src/main/frontend/menu.cpp
@@ -53,6 +53,7 @@ namespace
     const char* PIXEL_SCALER_LABEL = "PIXEL SCALER ";
     const char* SELECTION_TIMER_LABEL = "SELECTION TIMER ";
     const char* BUMPER_HEIGHT_LABEL = "BUMPER HEIGHT ";
+    const char* FERRARI_MIRROR_FIX_LABEL = "FERRARI MIRROR FIX ";
 
     const char* BUMPER_HEIGHT_NAMES[Config::BUMPER_VIEW_HEIGHT_LEVELS] =
     {
@@ -109,6 +110,12 @@ namespace
     {
         const int level = config.bumper_view_height_level();
         return std::string(BUMPER_HEIGHT_LABEL) + BUMPER_HEIGHT_NAMES[level];
+    }
+
+    std::string ferrari_mirror_fix_menu_text()
+    {
+        return std::string(FERRARI_MIRROR_FIX_LABEL) +
+            (config.ferrari_mirror_fix() ? "ON" : "OFF");
     }
 
     void sync_feedback_for_input_mode()
@@ -350,6 +357,56 @@ void Menu::tick()
         {
             *bumper_entry = bumper_height_menu_text();
         }
+    }
+
+    // Keep the Ferrari detail correction visible in Enhancements. OFF is the
+    // untouched arcade/CannonBall behavior where the complete sprite, including
+    // the badge and number plate, is mirrored on left-facing Ferrari frames.
+    if (!menu_enhancements.empty())
+    {
+        auto fix_entry = std::find_if(
+            menu_enhancements.begin(),
+            menu_enhancements.end(),
+            [](const std::string& entry)
+            {
+                return starts_with_label(entry, FERRARI_MIRROR_FIX_LABEL);
+            });
+
+        if (fix_entry == menu_enhancements.end())
+        {
+            auto insert_before = std::find_if(
+                menu_enhancements.begin(),
+                menu_enhancements.end(),
+                [](const std::string& entry)
+                {
+                    return starts_with_label(entry, ENTRY_BACK);
+                });
+
+            menu_enhancements.insert(insert_before, ferrari_mirror_fix_menu_text());
+        }
+        else
+        {
+            *fix_entry = ferrari_mirror_fix_menu_text();
+        }
+    }
+
+    // LEFT/RIGHT set this boolean directly like the other DX value options.
+    // Enter remains a toggle fallback in select_pressed().
+    if (state == STATE_MENU &&
+        menu_selected == &menu_enhancements &&
+        cursor >= 0 &&
+        cursor < static_cast<int>(menu_enhancements.size()) &&
+        starts_with_label(menu_enhancements[cursor], FERRARI_MIRROR_FIX_LABEL) &&
+        (input.has_pressed(Input::LEFT) || input.has_pressed(Input::RIGHT)))
+    {
+        const bool target = input.has_pressed(Input::RIGHT);
+        if (config.ferrari_mirror_fix() != target)
+        {
+            config.set_ferrari_mirror_fix(target);
+            menu_enhancements[cursor] = ferrari_mirror_fix_menu_text();
+            config_save_pending = true;
+        }
+        osoundint.queue_sound(sound::BEEP1);
     }
 
     // The original frontend uses analog steering as a menu up/down control.
@@ -604,6 +661,13 @@ bool Menu::select_pressed()
         cursor < static_cast<int>(menu_enhancements.size()))
     {
         const std::string& option = menu_enhancements[cursor];
+
+        if (starts_with_label(option, FERRARI_MIRROR_FIX_LABEL))
+        {
+            config.toggle_ferrari_mirror_fix();
+            menu_enhancements[cursor] = ferrari_mirror_fix_menu_text();
+            return false;
+        }
 
         if (starts_with_label(option, PIXEL_SCALER_LABEL))
         {

--- a/src/main/hwvideo/hwsprites.cpp
+++ b/src/main/hwvideo/hwsprites.cpp
@@ -80,6 +80,97 @@ DEFINE_RW_FUNCS(uint8_t,  u8)
 DEFINE_RW_FUNCS(uint16_t, u16)
 DEFINE_RW_FUNCS(uint32_t, u32)
 
+namespace
+{
+    struct FerrariMirrorRect
+    {
+        int x0;
+        int x1;
+        int y0;
+        int y1;
+    };
+
+    struct FerrariMirrorFix
+    {
+        uint32_t offset_words;
+        int pitch_words;
+        int width;
+        FerrariMirrorRect logo;
+        FerrariMirrorRect plate;
+    };
+
+    // These are the ten Ferrari ROM frames where a left-facing HFLIP leaves
+    // readable asymmetric rear details. Coordinates were measured directly
+    // from the original 4-bit sprite data exported by CannonBall DX.
+    constexpr FerrariMirrorFix FERRARI_MIRROR_FIXES[] =
+    {
+        {    0, 11,  88, {40, 46, 27, 33}, {36, 50, 35, 39} }, // F236
+        {  484, 11,  88, {40, 46, 19, 25}, {36, 51, 27, 32} }, // F240
+        {  935, 11,  88, {40, 46, 11, 17}, {36, 51, 19, 25} }, // F24A
+        { 1331, 11,  88, {39, 45, 27, 33}, {35, 50, 35, 39} }, // F254
+        { 1815, 11,  88, {39, 45, 19, 25}, {35, 50, 27, 32} }, // F25E
+        { 2266, 11,  88, {39, 45, 11, 17}, {35, 50, 19, 25} }, // F268
+        { 2662, 11,  88, {38, 44, 27, 33}, {34, 49, 35, 39} }, // F272
+        { 3146, 11,  88, {38, 44, 19, 25}, {34, 49, 27, 32} }, // F27C
+        { 3597, 11,  88, {38, 44, 11, 17}, {34, 49, 19, 25} }, // F286
+        { 9353, 17, 136, {34, 40, 19, 25}, {31, 44, 27, 33} }, // F4E8
+    };
+
+    const FerrariMirrorFix* find_ferrari_mirror_fix(
+        int bank,
+        uint32_t offset_words,
+        int pitch_words)
+    {
+        if (bank != 0)
+            return nullptr;
+
+        for (const FerrariMirrorFix& fix : FERRARI_MIRROR_FIXES)
+        {
+            if (fix.offset_words == offset_words &&
+                fix.pitch_words == pitch_words)
+            {
+                return &fix;
+            }
+        }
+
+        return nullptr;
+    }
+
+    uint8_t read_sprite_pixel(const uint32_t* row, int x)
+    {
+        const int shift = 28 - ((x & 7) << 2);
+        return static_cast<uint8_t>((row[x >> 3] >> shift) & 0x0f);
+    }
+
+    void write_sprite_pixel(uint32_t* row, int x, uint8_t pixel)
+    {
+        const int shift = 28 - ((x & 7) << 2);
+        const uint32_t mask = 0x0fu << shift;
+        row[x >> 3] =
+            (row[x >> 3] & ~mask) |
+            ((static_cast<uint32_t>(pixel) & 0x0fu) << shift);
+    }
+
+    void restore_unmirrored_rect(
+        const uint32_t* source_row,
+        uint32_t* flipped_row,
+        int sprite_width,
+        int row,
+        const FerrariMirrorRect& rect)
+    {
+        if (row < rect.y0 || row > rect.y1)
+            return;
+
+        int dest_x = sprite_width - 1 - rect.x1;
+        for (int source_x = rect.x0; source_x <= rect.x1; source_x++, dest_x++)
+        {
+            write_sprite_pixel(
+                flipped_row,
+                dest_x,
+                read_sprite_pixel(source_row, source_x));
+        }
+    }
+}
 
 
 hwsprites::hwsprites()
@@ -415,6 +506,17 @@ reps[i]++;\
 
 void hwsprites::render(uint16_t* pixels, const uint8_t priority)
 {
+    // Flipped sprite rows are cached. If the user changes the Ferrari detail
+    // option at runtime, invalidate only that derived cache so the very next
+    // frame is rebuilt with the selected original/fixed behavior.
+    const bool ferrari_mirror_fix_enabled = config.ferrari_mirror_fix();
+    static bool ferrari_mirror_fix_cached_state = ferrari_mirror_fix_enabled;
+    if (ferrari_mirror_fix_enabled != ferrari_mirror_fix_cached_state)
+    {
+        std::fill_n(sprites_flipped, std::size(sprites_flipped), 0xffffffff);
+        ferrari_mirror_fix_cached_state = ferrari_mirror_fix_enabled;
+    }
+
     static uint32_t reps[6] = {0,0,0,0,0,0};
 
     static uint32_t freq[32];
@@ -536,6 +638,11 @@ void hwsprites::render(uint16_t* pixels, const uint8_t priority)
             // first encounter of sprite, created flipped entry
             shadowaddr -= (pitch - 1); // start of data, if unflipped
 
+            const FerrariMirrorFix* ferrari_fix =
+                ferrari_mirror_fix_enabled
+                    ? find_ferrari_mirror_fix(bank, shadowaddr, pitch)
+                    : nullptr;
+
             for (int y = 0; y < sprite_height; y++) {
 //            for (int y = 0; y < height; y++) {
                 // calculate the addresses for this line
@@ -575,6 +682,26 @@ std::cout << "\r\t\t\t\t" << processed_lines << " sprite lines flipped";
                             (px[6] << 24) |
                             (px[7] << 28);
                     };
+
+                    if (ferrari_fix)
+                    {
+                        const uint32_t* source_row = spriterom + shadowaddr;
+                        uint32_t* flipped_row = spriterom_flipped + shadowaddr;
+
+                        restore_unmirrored_rect(
+                            source_row,
+                            flipped_row,
+                            ferrari_fix->width,
+                            y,
+                            ferrari_fix->logo);
+                        restore_unmirrored_rect(
+                            source_row,
+                            flipped_row,
+                            ferrari_fix->width,
+                            y,
+                            ferrari_fix->plate);
+                    }
+
                     spriterom_shadowinfo[shadowaddr] = shadow_found;
                 }
                 shadowaddr += pitch;


### PR DESCRIPTION
Promote the tested Ferrari mirror correction to master. Keeps the Ferrari badge and number plate readable on mirrored left-facing frames while preserving the original behavior behind an Enhancements toggle (`FERRARI MIRROR FIX`). Default remains ON; OFF restores the untouched original sprite mirroring.