### PR TITLE
Fix automatic gear setting persistence

### DIFF
--- a/src/main/frontend/config.cpp
+++ b/src/main/frontend/config.cpp
@@ -156,7 +156,6 @@ namespace
     {
         // First-run controller profile. These are SDL GameController values,
         // so an Xbox 360/XInput-style pad works immediately without setup.
-        controls.gear = controls_settings_t::GEAR_SEPARATE;
         controls.analog = 1;
 
         controls.axis[0] = SDL_CONTROLLER_AXIS_LEFTX;


### PR DESCRIPTION
## Fix
Prevent the temporary first-run/default gamepad profile from overwriting the persisted gear mode.

`controls.gear` is already loaded and saved correctly by the base configuration code, with `GEAR_AUTO = 3`. However, while `controls.default_gamepad` remained pending, `apply_default_gamepad_legacy_bindings()` forced the runtime value back to `GEAR_SEPARATE` on every launch. This also made a manually configured `<gear>3</gear>` appear to be ignored.

The default gamepad helper now only initializes controller bindings/axis defaults and leaves the user's global gear mode untouched.

### Expected result
- Select **Automatic** gears.
- Exit CannonBall DX.
- Restart.
- **Automatic** remains selected.
- `<gear>3</gear>` is respected.
- Fresh installs retain the existing default gear mode via the normal config fallback.