### PR TITLE
Add 16:10 aspect ratio support for Steam Deck

### DIFF
--- a/src/main/frontend/config_base.cpp
+++ b/src/main/frontend/config_base.cpp
@@ -681,11 +681,8 @@ void Config::load_stats()
     }
 
     // Load machine stats from file
-    for (int i = 0; i < 1; i++)
-    {
-        stats.playcount = stats_data.get_int("playcount", 0);
-        stats.runtime   = stats_data.get_int("runtime",   0);
-    }
+    stats.playcount = stats_data.get_int("playcount", 0);
+    stats.runtime   = stats_data.get_int("runtime",   0);
 }
 
 void Config::save_stats()

--- a/src/main/frontend/config_base.cpp
+++ b/src/main/frontend/config_base.cpp
@@ -212,7 +212,7 @@ void Config::load()
     if (video.fps != 0 && video.fps != 3)
         video.fps = 2;
     video.fps_count     = cfg.get_int("video.fps_counter",     0); // FPS Counter
-    video.widescreen    = cfg.get_int("video.widescreen",      0); // Aspect: 0=4:3, 1=16:9, 2=21:9, 3=stretched
+    video.widescreen    = cfg.get_int("video.widescreen",      0); // Aspect: 0=4:3, 1=16:9, 2=21:9, 3=stretched, 4=16:10
 
     // Legacy mode 2 used to mean stretched fullscreen. Stretching is now an
     // aspect-ratio choice, leaving display mode free for real exclusive fullscreen.
@@ -228,7 +228,7 @@ void Config::load()
         video.mode = video_settings_t::MODE_FULL;
     }
 
-    if (video.widescreen < 0 || video.widescreen > 3)
+    if (video.widescreen < 0 || video.widescreen > 4)
         video.widescreen = 0;
 
     video.hires_next    =
@@ -681,8 +681,11 @@ void Config::load_stats()
     }
 
     // Load machine stats from file
-    stats.playcount = stats_data.get_int("playcount", 0);
-    stats.runtime   = stats_data.get_int("runtime",   0);
+    for (int i = 0; i < 1; i++)
+    {
+        stats.playcount = stats_data.get_int("playcount", 0);
+        stats.runtime   = stats_data.get_int("runtime",   0);
+    }
 }
 
 void Config::save_stats()

--- a/src/main/frontend/menu.hpp
+++ b/src/main/frontend/menu.hpp
@@ -548,6 +548,43 @@ protected:
         if (cannonball::state != cannonball::STATE_GAME)
             radio_button::stop_engine_vibration();
 
+        // ASPECT RATIO is handled here so DX can extend the preserved SE range
+        // without changing the legacy meaning of value 3 (STRETCHED). Value 4
+        // is the new 16:10 mode used by Steam Deck-class displays.
+        if (!config.smartypi.enabled &&
+            menu_selected == &menu_video &&
+            cursor >= 0 &&
+            cursor < static_cast<int>(menu_video.size()) &&
+            menu_video[cursor].rfind(ENTRY_WIDESCREEN, 0) == 0)
+        {
+            int direction = 0;
+            if (input.has_pressed(Input::LEFT))
+                direction = -1;
+            else if (input.has_pressed(Input::RIGHT))
+                direction = 1;
+
+            const bool selected = direction == 0 && select_pressed();
+            if (direction != 0 || selected)
+            {
+                int next = config.video.widescreen + (direction < 0 ? -1 : 1);
+                if (next < 0)
+                    next = 4;
+                else if (next > 4)
+                    next = 0;
+
+                if (next != config.video.widescreen)
+                {
+                    config.video.widescreen = next;
+                    config.videoRestartRequired = true;
+                    directional_save_pending = true;
+                }
+
+                osoundint.queue_sound(sound::BEEP1);
+                refresh_menu();
+                return;
+            }
+        }
+
         // Once inside the FFB tuning pages, use the DX handler so engine
         // vibration strength and period live beside the existing effect values
         // without adding another option to the main Controls page.

--- a/src/main/frontend/menu.hpp
+++ b/src/main/frontend/menu.hpp
@@ -548,9 +548,8 @@ protected:
         if (cannonball::state != cannonball::STATE_GAME)
             radio_button::stop_engine_vibration();
 
-        // ASPECT RATIO is handled here so DX can extend the preserved SE range
-        // without changing the legacy meaning of value 3 (STRETCHED). Value 4
-        // is the new 16:10 mode used by Steam Deck-class displays.
+        // Keep the visible order intuitive without changing the persisted
+        // numeric values: 0=4:3, 1=16:9, 4=16:10, 2=21:9, 3=STRETCHED.
         if (!config.smartypi.enabled &&
             menu_selected == &menu_video &&
             cursor >= 0 &&
@@ -566,11 +565,20 @@ protected:
             const bool selected = direction == 0 && select_pressed();
             if (direction != 0 || selected)
             {
-                int next = config.video.widescreen + (direction < 0 ? -1 : 1);
-                if (next < 0)
-                    next = 4;
-                else if (next > 4)
-                    next = 0;
+                static const int ASPECT_ORDER[5] = { 0, 1, 4, 2, 3 };
+                int order_index = 0;
+                for (int i = 0; i < 5; ++i)
+                {
+                    if (ASPECT_ORDER[i] == config.video.widescreen)
+                    {
+                        order_index = i;
+                        break;
+                    }
+                }
+
+                const int step = direction < 0 ? -1 : 1;
+                order_index = (order_index + step + 5) % 5;
+                const int next = ASPECT_ORDER[order_index];
 
                 if (next != config.video.widescreen)
                 {

--- a/src/main/frontend/menulabels.hpp
+++ b/src/main/frontend/menulabels.hpp
@@ -139,6 +139,7 @@ const static char* ENTRY_SPRITERES          = "SPRITE RESOLUTION ";
 const static char* ENTRY_ATTRACT            = "NEW ATTRACT ";
 const static char* ENTRY_PROTOTYPE          = "PROTOTYPE STAGE 1 ";
 const static char* ENTRY_OBJECTS            = "OBJECTS ";
+const static char* ENTRY_TIMER              = "TIMING FIXES ";
 
 // Game Engine: Car Setup Sub-Menu
 const static char* ENTRY_GRIP               = "GRIPPY TYRES ";
@@ -160,6 +161,6 @@ const static char* GEAR_LABELS[4] = {"MANUAL", "MANUAL CABINET", "MANUAL 2 BUTTO
 const static char* FPS_LABELS[4] = { "30 FPS", "ORIGINAL", "60 FPS", "120 FPS" };
 const static char* ANALOG_LABELS[3] = { "OFF", "ON", "ON WHEEL ONLY" };
 const static char* VIDEO_LABELS[4] = { "WINDOWED", "FULLSCREEN", "LEGACY STRETCH", "FULLSCREEN EXCLUSIVE" };
-const static char* ASPECT_LABELS[4] = { "4-3", "16-9", "21-9", "STRETCHED" };
+const static char* ASPECT_LABELS[5] = { "4-3", "16-9", "21-9", "STRETCHED", "16-10" };
 const static char* RUMBLE_LABELS[5] = { "OFF", "LOW", "MED", "HIGH", "FULL" };
 const static char* CAB_LABELS[3] = { "MOVING", "UPRIGHT", "MINI" };

--- a/src/main/frontend/menulabels.hpp
+++ b/src/main/frontend/menulabels.hpp
@@ -139,7 +139,6 @@ const static char* ENTRY_SPRITERES          = "SPRITE RESOLUTION ";
 const static char* ENTRY_ATTRACT            = "NEW ATTRACT ";
 const static char* ENTRY_PROTOTYPE          = "PROTOTYPE STAGE 1 ";
 const static char* ENTRY_OBJECTS            = "OBJECTS ";
-const static char* ENTRY_TIMER              = "TIMING FIXES ";
 
 // Game Engine: Car Setup Sub-Menu
 const static char* ENTRY_GRIP               = "GRIPPY TYRES ";

--- a/src/main/globals.hpp
+++ b/src/main/globals.hpp
@@ -36,6 +36,10 @@ const bool FORCE_AI = false;
 const uint16_t S16_WIDTH      = 320;
 const uint16_t S16_HEIGHT     = 224;
 
+// Internal 16:10 width. 356 keeps the source close to 16:10 while preserving
+// the SIMD-friendly Blargg input alignment used by the existing wide modes.
+const uint16_t S16_WIDTH_16_10 = 356;
+
 // Internal Widescreen Width
 // JJP - was 398. Using 404 allows for optimisation of Blargg filter with SIMD.
 const uint16_t S16_WIDTH_WIDE = 404;

--- a/src/main/video_bugfix_base.cpp
+++ b/src/main/video_bugfix_base.cpp
@@ -151,6 +151,11 @@ int Video::set_video_mode(video_settings_t* settings)
 {
     switch (settings->widescreen)
     {
+    case 4: // 16:10
+        config.s16_width = S16_WIDTH_16_10;
+        config.s16_x_off = (S16_WIDTH_16_10 - S16_WIDTH) / 2;
+        break;
+
     case 2: // 21:9
         config.s16_width = S16_WIDTH_ULTRAWIDE;
         config.s16_x_off = (S16_WIDTH_ULTRAWIDE - S16_WIDTH) / 2;
@@ -161,7 +166,7 @@ int Video::set_video_mode(video_settings_t* settings)
         config.s16_x_off = (S16_WIDTH_WIDE - S16_WIDTH) / 2;
         break;
 
-    default: // 4:3
+    default: // 4:3 / stretched output
         config.s16_width = S16_WIDTH;
         config.s16_x_off = 0;
         break;
@@ -392,7 +397,6 @@ void Video::write_tile16(uint32_t* addr, const uint16_t data)
 {
     tile_layer->tile_ram[*addr & 0xFFFF] = (data >> 8) & 0xFF;
     tile_layer->tile_ram[(*addr+1) & 0xFFFF] = data & 0xFF;
-
     *addr += 2;
 }
 */

--- a/src/main/video_bugfix_base.cpp
+++ b/src/main/video_bugfix_base.cpp
@@ -397,6 +397,7 @@ void Video::write_tile16(uint32_t* addr, const uint16_t data)
 {
     tile_layer->tile_ram[*addr & 0xFFFF] = (data >> 8) & 0xFF;
     tile_layer->tile_ram[(*addr+1) & 0xFFFF] = data & 0xFF;
+
     *addr += 2;
 }
 */


### PR DESCRIPTION
## Summary
- add a dedicated 16:10 aspect-ratio option for Steam Deck-class displays
- preserve existing config compatibility: `3` remains `STRETCHED`, new 16:10 mode is `4`
- add a 356x224 internal render width so the existing optimized Blargg/SIMD path keeps its required input alignment
- make the new aspect available through the existing Video menu with keyboard/D-pad left/right and normal select cycling
- persist the new aspect mode in `config.xml`

## Compatibility
Existing 4:3, 16:9, 21:9 and stretched configurations keep their current numeric values and behaviour. The 21:9-only side-art path is unchanged.

## Verification
- reviewed all changed files against `master`
- verified the optimized hires Blargg path processes the new 712-pixel 2x width with the same 24n+16 alignment as the existing 640/808/1072 widths
- no local runtime build was available in this session, so final visual verification should be done on Steam Deck / a 1280x800 display before merging